### PR TITLE
fixed pkg references pointing to openshift-pipelines

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -43,10 +43,10 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.1.7
       with:
-        path: ./src/github.com/openshift-pipelines/tektoncd-pruner
+        path: ./src/github.com/tektoncd/pruner
 
     - name: Create kind cluster
-      working-directory: ./src/github.com/openshift-pipelines/tektoncd-pruner
+      working-directory: ./src/github.com/tektoncd/pruner
       run: |  
         kind create cluster --config "./test/kind-cluster.yaml" --wait=60s
         while ! kubectl get nodes 
@@ -56,7 +56,7 @@ jobs:
         done
 
     - name: Install Tekton pipelines
-      working-directory: ./src/github.com/openshift-pipelines/tektoncd-pruner
+      working-directory: ./src/github.com/tektoncd/pruner
       run: |
         while ! kubectl apply --filename ${{ env.TEKTON_PIPELINES_RELEASE }}
         do
@@ -68,7 +68,7 @@ jobs:
         kubectl -n tekton-pipelines delete po -l app=tekton-pipelines-controller
 
     - name: Install all the everythings
-      working-directory: ./src/github.com/openshift-pipelines/tektoncd-pruner
+      working-directory: ./src/github.com/tektoncd/pruner
       timeout-minutes: 10
       run: |
         export KO_DOCKER_REPO=kind.local
@@ -76,7 +76,7 @@ jobs:
         sleep 10
 
     - name: Run Integration tests
-      working-directory: ./src/github.com/openshift-pipelines/tektoncd-pruner
+      working-directory: ./src/github.com/tektoncd/pruner
       run: |
         echo "Running Go e2e tests"
         set +e

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
               desc: use sigs.k8s.io/yaml instead, to be consistent
     errcheck:
       exclude-functions:
-        - (*github.com/openshift-pipelines/tektoncd-pruner/vendor/go.uber.org/zap.SugaredLogger).Sync
+        - (*github.com/tektoncd/pruner/vendor/go.uber.org/zap.SugaredLogger).Sync
         - flag.Set
         - os.Setenv
         - logger.Sync

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -69,7 +69,7 @@ spec:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: ko://github.com/openshift-pipelines/tektoncd-pruner/cmd/controller
+          image: ko://github.com/tektoncd/pruner/cmd/controller
           resources:
             requests:
               cpu: 100m

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift-pipelines/tektoncd-pruner
+module github.com/tektoncd/pruner
 
 go 1.24.0
 

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"os"
 
-	"github.com/openshift-pipelines/tektoncd-pruner/pkg/config"
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/taskrun"
 	taskrunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/taskrun"
+	"github.com/tektoncd/pruner/pkg/config"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/reconciler/taskrun/reconciler_test.go
+++ b/pkg/reconciler/taskrun/reconciler_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift-pipelines/tektoncd-pruner/pkg/config"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	fakepipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	"github.com/tektoncd/pruner/pkg/config"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
# Changes

This pull request updates the project to use the new module path `github.com/tektoncd/pruner` instead of the previous `github.com/openshift-pipelines/tektoncd-pruner`. The changes ensure consistency across the codebase, configuration files, and CI/CD workflows by updating all relevant references to the new path.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
