### PR TITLE
.github/workflows: use go.mod to get the go version

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ^1.23
+          go-version-file: "go.mod"
 
       - name: cache go modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
         with:
-          go-version: "1.23.x"
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      GOPATH: ${{ github.workspace }}
-      GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KO_DOCKER_REPO: kind.local
       KOCACHE: ~/ko
@@ -31,22 +29,19 @@ jobs:
       # the places this is used.
 
     steps:
+    - name: Check out our repo
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.1.7
+
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.22.x
+        go-version-file: "go.mod"
 
     - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
       with:
         version: tip
 
-    - name: Check out our repo
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.1.7
-      with:
-        path: ./src/github.com/tektoncd/pruner
-
     - name: Create kind cluster
-      working-directory: ./src/github.com/tektoncd/pruner
       run: |  
         kind create cluster --config "./test/kind-cluster.yaml" --wait=60s
         while ! kubectl get nodes 
@@ -56,7 +51,6 @@ jobs:
         done
 
     - name: Install Tekton pipelines
-      working-directory: ./src/github.com/tektoncd/pruner
       run: |
         while ! kubectl apply --filename ${{ env.TEKTON_PIPELINES_RELEASE }}
         do
@@ -68,7 +62,6 @@ jobs:
         kubectl -n tekton-pipelines delete po -l app=tekton-pipelines-controller
 
     - name: Install all the everythings
-      working-directory: ./src/github.com/tektoncd/pruner
       timeout-minutes: 10
       run: |
         export KO_DOCKER_REPO=kind.local
@@ -76,7 +69,6 @@ jobs:
         sleep 10
 
     - name: Run Integration tests
-      working-directory: ./src/github.com/tektoncd/pruner
       run: |
         echo "Running Go e2e tests"
         set +e


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This remove the error of mismatch go versions, and doesn't require us to update the CI definitions if we update go in go.mod.

Also:
- checkout the repository first (to get go.mod)
- check it out in the current folder, no need for src/...

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
