### PR TITLE
fix: include validation for forbidden namespaces

### DIFF
--- a/config/601-webhook-configuration.yaml
+++ b/config/601-webhook-configuration.yaml
@@ -93,8 +93,6 @@ webhooks:
             - kube-system
             - kube-public
             - kube-node-lease
-            - tekton-pipelines
-            - default
     objectSelector:
       matchLabels:
         app.kubernetes.io/part-of: tekton-pruner


### PR DESCRIPTION
# Changes

This pull request introduces a new validation to prevent namespace-level configuration from being created in certain forbidden namespaces, specifically those prefixed with `kube-`, `openshift-`, or `tekton-`. The changes include the implementation of the validation logic, updates to the admission webhook, and tests to ensure correct enforcement.

* Added a new function `validateNamespaceForConfig` in `pkg/webhook/configmapvalidation.go` that checks if a namespace starts with `kube-`, `openshift-`, or `tekton-` and returns an error if so. This prevents creation of namespace-level configs in these forbidden namespaces.
* Updated the `Admit` method in `ValidateConfigMap` to invoke `validateNamespaceForConfig` for namespace-level configs and reject requests in forbidden namespaces, returning a detailed error response.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind fix