### PR TITLE
feature: support resource selectors in namespace configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,21 +120,31 @@ data:
 
 ### Resource Groups (Fine-grained Control)
 
-Group resources by labels/annotations for different policies:
+Group resources by labels/annotations for different policies within a namespace.
+
+**Note:** Selectors only work in namespace-level ConfigMaps, not global ConfigMaps.
 
 ```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: my-app
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
 data:
-  global-config: |
+  ns-config: |
     pipelineRuns:
       - selector:
           matchLabels:
             environment: production
-        ttlSecondsAfterFinished: 604800  # 7 days
+        ttlSecondsAfterFinished: 604800
         successfulHistoryLimit: 10
       - selector:
           matchLabels:
             environment: development
-        ttlSecondsAfterFinished: 300     # 5 minutes
+        ttlSecondsAfterFinished: 300
         successfulHistoryLimit: 3
 ```
 

--- a/docs/tutorials/sample-configMaps/01-basic-global.yaml
+++ b/docs/tutorials/sample-configMaps/01-basic-global.yaml
@@ -1,0 +1,18 @@
+# Basic Global Configuration
+# Simplest setup with cluster-wide defaults
+# All PipelineRuns and TaskRuns in all namespaces use these settings
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-default-spec
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: global
+data:
+  global-config: |
+    enforcedConfigLevel: global
+    ttlSecondsAfterFinished: 3600
+    successfulHistoryLimit: 5
+    failedHistoryLimit: 3

--- a/docs/tutorials/sample-configMaps/02-global-with-namespace-inline.yaml
+++ b/docs/tutorials/sample-configMaps/02-global-with-namespace-inline.yaml
@@ -1,0 +1,35 @@
+# Global Configuration with Inline Namespace Overrides
+# Centralized management with different settings per namespace
+# Useful when you want to manage all configuration in one place
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-default-spec
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: global
+data:
+  global-config: |
+    enforcedConfigLevel: namespace
+    
+    ttlSecondsAfterFinished: 604800
+    successfulHistoryLimit: 5
+    failedHistoryLimit: 5
+    
+    namespaces:
+      development:
+        ttlSecondsAfterFinished: 300
+        successfulHistoryLimit: 3
+        failedHistoryLimit: 2
+      
+      staging:
+        ttlSecondsAfterFinished: 86400
+        successfulHistoryLimit: 10
+        failedHistoryLimit: 5
+      
+      production:
+        ttlSecondsAfterFinished: 604800
+        successfulHistoryLimit: 20
+        failedHistoryLimit: 10

--- a/docs/tutorials/sample-configMaps/03-global-enable-namespace-configmaps.yaml
+++ b/docs/tutorials/sample-configMaps/03-global-enable-namespace-configmaps.yaml
@@ -1,0 +1,40 @@
+# Global Configuration Enabling Namespace-Level ConfigMaps
+# This enables self-service: namespace owners can create their own ConfigMaps
+# Recommended for multi-tenant clusters
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-default-spec
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: global
+data:
+  global-config: |
+    enforcedConfigLevel: namespace
+    
+    ttlSecondsAfterFinished: 3600
+    successfulHistoryLimit: 5
+    failedHistoryLimit: 5
+
+---
+# Example: Namespace-specific ConfigMap (created by namespace owner)
+# IMPORTANT: 
+#   - Name MUST be: tekton-pruner-namespace-spec
+#   - Create in user namespace (NOT tekton-pipelines)
+#   - Cannot be created in kube-*, openshift-*, or tekton-* namespaces
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: my-app-namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 300
+    successfulHistoryLimit: 3
+    failedHistoryLimit: 5

--- a/docs/tutorials/sample-configMaps/04-namespace-basic.yaml
+++ b/docs/tutorials/sample-configMaps/04-namespace-basic.yaml
@@ -1,0 +1,18 @@
+# Namespace-Specific ConfigMap with Basic Configuration
+# Fixed name REQUIRED: tekton-pruner-namespace-spec
+# This ConfigMap MUST be created in the user namespace (NOT tekton-pipelines)
+# Cannot be created in: kube-*, openshift-*, or tekton-* namespaces
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec     # Fixed name - DO NOT CHANGE
+  namespace: my-app-namespace            # User application namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 300
+    successfulHistoryLimit: 3
+    failedHistoryLimit: 5

--- a/docs/tutorials/sample-configMaps/05-namespace-label-selectors.yaml
+++ b/docs/tutorials/sample-configMaps/05-namespace-label-selectors.yaml
@@ -1,0 +1,56 @@
+# Namespace-Specific ConfigMap with Label Selectors
+# Demonstrates resource groups within a single namespace using labels
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: development                 # User namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 600
+    successfulHistoryLimit: 3
+    failedHistoryLimit: 3
+    
+    pipelineRuns:
+      - selector:
+        - matchLabels:
+            priority: high
+        ttlSecondsAfterFinished: 3600
+        successfulHistoryLimit: 10
+        failedHistoryLimit: 5
+      
+      - selector:
+        - matchLabels:
+            priority: low
+        ttlSecondsAfterFinished: 300
+        successfulHistoryLimit: 1
+        failedHistoryLimit: 2
+      
+      - selector:
+        - matchLabels:
+            pipeline-type: ci
+        ttlSecondsAfterFinished: 600
+        successfulHistoryLimit: 3
+      
+      - selector:
+        - matchLabels:
+            pipeline-type: cd
+        ttlSecondsAfterFinished: 1800
+        successfulHistoryLimit: 5
+    
+    taskRuns:
+      - selector:
+        - matchLabels:
+            task-type: test
+        ttlSecondsAfterFinished: 300
+        successfulHistoryLimit: 2
+      
+      - selector:
+        - matchLabels:
+            task-type: build
+        ttlSecondsAfterFinished: 600
+        successfulHistoryLimit: 3

--- a/docs/tutorials/sample-configMaps/06-namespace-annotation-selectors.yaml
+++ b/docs/tutorials/sample-configMaps/06-namespace-annotation-selectors.yaml
@@ -1,0 +1,58 @@
+# Namespace-Specific ConfigMap with Annotation Selectors
+# Useful when PipelineRuns/TaskRuns are annotated by external systems
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: ci-cd                       # User namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 1800
+    successfulHistoryLimit: 5
+    failedHistoryLimit: 5
+    
+    pipelineRuns:
+      - selector:
+        - matchAnnotations:
+            release-pipeline: "true"
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 50
+        failedHistoryLimit: 20
+      
+      - selector:
+        - matchAnnotations:
+            build-schedule: "nightly"
+        ttlSecondsAfterFinished: 86400
+        successfulHistoryLimit: 7
+        failedHistoryLimit: 7
+      
+      - selector:
+        - matchAnnotations:
+            trigger-type: "pull-request"
+        ttlSecondsAfterFinished: 300
+        successfulHistoryLimit: 1
+        failedHistoryLimit: 2
+      
+      - selector:
+        - matchAnnotations:
+            trigger-type: "manual"
+        ttlSecondsAfterFinished: 3600
+        successfulHistoryLimit: 5
+    
+    taskRuns:
+      - selector:
+        - matchAnnotations:
+            scan-type: "security"
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 100
+        failedHistoryLimit: 100
+      
+      - selector:
+        - matchAnnotations:
+            scan-type: "quality"
+        ttlSecondsAfterFinished: 604800
+        successfulHistoryLimit: 20

--- a/docs/tutorials/sample-configMaps/07-namespace-mixed-selectors.yaml
+++ b/docs/tutorials/sample-configMaps/07-namespace-mixed-selectors.yaml
@@ -1,0 +1,63 @@
+# Namespace-Specific ConfigMap with Mixed Selectors
+# Combines both labels AND annotations for precise matching
+# When both are specified, ALL conditions must match
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: production                  # User namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 86400
+    successfulHistoryLimit: 10
+    failedHistoryLimit: 10
+    
+    pipelineRuns:
+      - selector:
+        - matchLabels:
+            app: payment-service
+            tier: critical
+          matchAnnotations:
+            compliance-required: "true"
+            audit-log: "enabled"
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 50
+        failedHistoryLimit: 50
+      
+      - selector:
+        - matchLabels:
+            app: payment-service
+            environment: production
+        ttlSecondsAfterFinished: 604800
+        successfulHistoryLimit: 20
+        failedHistoryLimit: 10
+      
+      - selector:
+        - matchLabels:
+            deployment-strategy: canary
+          matchAnnotations:
+            monitoring: "enabled"
+        ttlSecondsAfterFinished: 259200
+        successfulHistoryLimit: 15
+    
+    taskRuns:
+      - selector:
+        - matchLabels:
+            task-category: security
+            component-tier: critical
+          matchAnnotations:
+            compliance-check: "required"
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 100
+      
+      - selector:
+        - matchLabels:
+            task-category: performance
+          matchAnnotations:
+            environment: "production"
+        ttlSecondsAfterFinished: 1209600
+        successfulHistoryLimit: 30

--- a/docs/tutorials/sample-configMaps/08-namespace-name-based.yaml
+++ b/docs/tutorials/sample-configMaps/08-namespace-name-based.yaml
@@ -1,0 +1,56 @@
+# Namespace-Specific ConfigMap with Name-Based Targeting
+# Target runs on specific pipelines or tasks by their exact name
+# Name matching takes precedence over selectors
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: app-builds                  # User namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 1800
+    successfulHistoryLimit: 5
+    failedHistoryLimit: 5
+    
+    pipelineRuns:
+      - name: production-deployment
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 50
+        failedHistoryLimit: 30
+      
+      - name: nightly-build
+        ttlSecondsAfterFinished: 86400
+        successfulHistoryLimit: 7
+        failedHistoryLimit: 7
+      
+      - name: integration-tests
+        ttlSecondsAfterFinished: 3600
+        successfulHistoryLimit: 5
+        failedHistoryLimit: 10
+      
+      - name: pr-validation
+        ttlSecondsAfterFinished: 300
+        successfulHistoryLimit: 1
+        failedHistoryLimit: 2
+    
+    taskRuns:
+      - name: vulnerability-scan
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 100
+        failedHistoryLimit: 100
+      
+      - name: sonar-scan
+        ttlSecondsAfterFinished: 604800
+        successfulHistoryLimit: 20
+      
+      - name: unit-tests
+        ttlSecondsAfterFinished: 600
+        successfulHistoryLimit: 3
+      
+      - name: build-image
+        ttlSecondsAfterFinished: 3600
+        successfulHistoryLimit: 5

--- a/docs/tutorials/sample-configMaps/09-namespace-complete.yaml
+++ b/docs/tutorials/sample-configMaps/09-namespace-complete.yaml
@@ -1,0 +1,146 @@
+# Namespace-Specific ConfigMap - Complete Production Example
+# Demonstrates all selector types in a production namespace
+# Combines name-based, label-based, annotation-based, and mixed selectors
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: ecommerce-prod              # Production user namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 604800
+    successfulHistoryLimit: 20
+    failedHistoryLimit: 10
+    
+    pipelineRuns:
+      - name: production-release-pipeline
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 50
+        failedHistoryLimit: 50
+      
+      - selector:
+        - matchLabels:
+            deployment-type: critical
+            service: payment
+          matchAnnotations:
+            compliance: "pci-dss"
+            audit-required: "true"
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 100
+        failedHistoryLimit: 100
+      
+      - selector:
+        - matchAnnotations:
+            tekton.dev/release: "true"
+        ttlSecondsAfterFinished: 1209600
+        successfulHistoryLimit: 30
+        failedHistoryLimit: 15
+      
+      - selector:
+        - matchLabels:
+            deployment-strategy: canary
+        ttlSecondsAfterFinished: 259200
+        successfulHistoryLimit: 15
+        failedHistoryLimit: 10
+      
+      - selector:
+        - matchLabels:
+            deployment-strategy: blue-green
+        ttlSecondsAfterFinished: 432000
+        successfulHistoryLimit: 20
+      
+      - selector:
+        - matchAnnotations:
+            deployment-type: "hotfix"
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 50
+        failedHistoryLimit: 50
+      
+      - selector:
+        - matchLabels:
+            pipeline-category: maintenance
+          matchAnnotations:
+            approval-required: "true"
+        ttlSecondsAfterFinished: 1209600
+        successfulHistoryLimit: 30
+    
+    taskRuns:
+      - name: security-vulnerability-scan
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 100
+        failedHistoryLimit: 100
+      
+      - selector:
+        - matchLabels:
+            task-category: security
+            scan-type: pci-compliance
+          matchAnnotations:
+            compliance-framework: "pci-dss"
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 100
+        failedHistoryLimit: 100
+      
+      - selector:
+        - matchAnnotations:
+            test-type: "penetration"
+            security-level: "critical"
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 50
+      
+      - selector:
+        - matchLabels:
+            task-category: performance
+        ttlSecondsAfterFinished: 604800
+        successfulHistoryLimit: 20
+        failedHistoryLimit: 10
+      
+      - selector:
+        - matchLabels:
+            test-type: load-test
+        ttlSecondsAfterFinished: 432000
+        successfulHistoryLimit: 15
+      
+      - name: db-migration
+        ttlSecondsAfterFinished: 2592000
+        successfulHistoryLimit: 50
+        failedHistoryLimit: 50
+      
+      - selector:
+        - matchAnnotations:
+            test-category: "smoke-test"
+        ttlSecondsAfterFinished: 86400
+        successfulHistoryLimit: 10
+      
+      - selector:
+        - matchLabels:
+            task-type: health-check
+            service-tier: critical
+          matchAnnotations:
+            monitoring: "enabled"
+        ttlSecondsAfterFinished: 604800
+        successfulHistoryLimit: 30
+      
+      - selector:
+        - matchLabels:
+            task-category: build
+        ttlSecondsAfterFinished: 86400
+        successfulHistoryLimit: 10
+        failedHistoryLimit: 5
+      
+      - selector:
+        - matchAnnotations:
+            quality-gate: "production"
+        ttlSecondsAfterFinished: 1209600
+        successfulHistoryLimit: 30
+
+# NOTES:
+# ------
+# 1. Selectors are evaluated in order - first match wins
+# 2. Name-based matching takes precedence over selectors
+# 3. When both matchLabels and matchAnnotations are specified, ALL must match
+# 4. Namespace config cannot exceed global limits (if global config sets limits)
+# 5. This ConfigMap can only be created in user namespaces (not kube-*, openshift-*, tekton-*)

--- a/docs/tutorials/time-based-pruning.md
+++ b/docs/tutorials/time-based-pruning.md
@@ -52,36 +52,46 @@ data:
       staging:
         ttlSecondsAfterFinished: 86400    # 1 day
       prod:
-        ttlSecondsAfterFinished: 2592000  # 30 days
+        ttlSecondsAfterFinished: 2592000
 ```
 
 ## Pipeline-specific TTLs
 
+Use selectors in namespace ConfigMaps for pipeline-specific TTLs:
+
 ```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: my-app
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
 data:
-  global-config: |
-    ttlSecondsAfterFinished: 3600  # Default: 1 hour
+  ns-config: |
+    ttlSecondsAfterFinished: 3600
     pipelineRuns:
       - selector:
           matchLabels:
             pipeline-type: release
-        ttlSecondsAfterFinished: 604800  # Releases: 7 days
+        ttlSecondsAfterFinished: 604800
       - selector:
           matchLabels:
             pipeline-type: test
-        ttlSecondsAfterFinished: 300     # Tests: 5 min
+        ttlSecondsAfterFinished: 300
 ```
 
 ## Combining TTL with History Limits
 
-History limits **override** TTL to guarantee minimum retention:
+History limits override TTL to guarantee minimum retention:
 
 ```yaml
 data:
-  global-config: |
-    ttlSecondsAfterFinished: 300      # Delete after 5 min
-    successfulHistoryLimit: 5          # BUT keep last 5 successful
-    failedHistoryLimit: 10             # AND keep last 10 failed
+  ns-config: |
+    ttlSecondsAfterFinished: 300
+    successfulHistoryLimit: 5
+    failedHistoryLimit: 10
 ```
 
 **Result**: Runs are deleted after 5 minutes UNLESS they're in the last 5 successful or last 10 failed.

--- a/pkg/config/config_selector_test.go
+++ b/pkg/config/config_selector_test.go
@@ -1,0 +1,485 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Helper function to create int32 pointer
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+
+// TestValidateConfigMap_GlobalWithSelectorsRejected verifies that global ConfigMaps
+// with selectors in namespace sections are REJECTED by validation
+func TestValidateConfigMap_GlobalWithSelectorsRejected(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     string
+		wantErrMsg string
+	}{
+		{
+			name: "global config with pipelineRuns selector should fail",
+			config: `ttlSecondsAfterFinished: 3600
+namespaces:
+  dev:
+    pipelineRuns:
+      - selector:
+          - matchLabels:
+              app: myapp
+        ttlSecondsAfterFinished: 1800`,
+			wantErrMsg: "global-config.namespaces.dev.pipelineRuns[0]: selectors are NOT supported in global ConfigMap",
+		},
+		{
+			name: "global config with taskRuns selector should fail",
+			config: `ttlSecondsAfterFinished: 3600
+namespaces:
+  prod:
+    taskRuns:
+      - selector:
+          - matchAnnotations:
+              team: platform
+        successfulHistoryLimit: 5`,
+			wantErrMsg: "global-config.namespaces.prod.taskRuns[0]: selectors are NOT supported in global ConfigMap",
+		},
+		{
+			name: "global config with multiple selectors should fail on first",
+			config: `namespaces:
+  dev:
+    pipelineRuns:
+      - selector:
+          - matchLabels:
+              app: myapp
+      - selector:
+          - matchLabels:
+              app: anotherapp`,
+			wantErrMsg: "global-config.namespaces.dev.pipelineRuns[0]: selectors are NOT supported in global ConfigMap",
+		},
+		{
+			name: "global config with mixed label and annotation selectors should fail",
+			config: `namespaces:
+  staging:
+    pipelineRuns:
+      - selector:
+          - matchLabels:
+              app: myapp
+            matchAnnotations:
+              version: v1`,
+			wantErrMsg: "global-config.namespaces.staging.pipelineRuns[0]: selectors are NOT supported in global ConfigMap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tekton-pruner-default-spec",
+					Namespace: "tekton-pipelines",
+				},
+				Data: map[string]string{
+					PrunerGlobalConfigKey: tt.config,
+				},
+			}
+
+			err := ValidateConfigMap(cm)
+			if err == nil {
+				t.Errorf("ValidateConfigMap() expected error containing '%s', got nil", tt.wantErrMsg)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("ValidateConfigMap() error = %v, want error containing %v", err, tt.wantErrMsg)
+			}
+		})
+	}
+}
+
+// TestValidateConfigMap_NamespaceWithSelectorsAccepted verifies that namespace ConfigMaps
+// with selectors ARE accepted by validation
+func TestValidateConfigMap_NamespaceWithSelectorsAccepted(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "namespace config with pipelineRuns selector should pass",
+			config: `pipelineRuns:
+  - selector:
+      - matchLabels:
+          app: myapp
+    ttlSecondsAfterFinished: 1800`,
+		},
+		{
+			name: "namespace config with taskRuns selector should pass",
+			config: `taskRuns:
+  - selector:
+      - matchAnnotations:
+          team: platform
+    successfulHistoryLimit: 5`,
+		},
+		{
+			name: "namespace config with mixed selectors should pass",
+			config: `pipelineRuns:
+  - selector:
+      - matchLabels:
+          app: myapp
+        matchAnnotations:
+          version: v1
+    ttlSecondsAfterFinished: 600`,
+		},
+		{
+			name: "namespace config with multiple resource specs should pass",
+			config: `pipelineRuns:
+  - selector:
+      - matchLabels:
+          app: app1
+    ttlSecondsAfterFinished: 1800
+  - selector:
+      - matchLabels:
+          app: app2
+    ttlSecondsAfterFinished: 3600`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tekton-pruner-namespace-spec",
+					Namespace: "dev",
+				},
+				Data: map[string]string{
+					PrunerNamespaceConfigKey: tt.config,
+				},
+			}
+
+			err := ValidateConfigMap(cm)
+			if err != nil {
+				t.Errorf("ValidateConfigMap() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+// TestGetFromPrunerConfigResourceLevelwithSelector_NamePrecedence verifies that
+// name-based matching has absolute precedence over selector-based matching
+func TestGetFromPrunerConfigResourceLevelwithSelector_NamePrecedence(t *testing.T) {
+	ttl1800 := int32(1800)
+	ttl3600 := int32(3600)
+
+	namespaceSpec := map[string]NamespaceSpec{
+		"dev": {
+			PipelineRuns: []ResourceSpec{
+				{
+					Name: "build-pipeline",
+					PrunerConfig: PrunerConfig{
+						TTLSecondsAfterFinished: &ttl1800, // Should match by name
+					},
+				},
+				{
+					Selector: []SelectorSpec{
+						{
+							MatchLabels: map[string]string{"app": "myapp"},
+						},
+					},
+					PrunerConfig: PrunerConfig{
+						TTLSecondsAfterFinished: &ttl3600, // Should NOT match even if labels match
+					},
+				},
+			},
+		},
+	}
+
+	selector := SelectorSpec{
+		MatchLabels: map[string]string{"app": "myapp"}, // This matches second spec
+	}
+
+	// Name should take precedence
+	result, identifiedBy := getFromPrunerConfigResourceLevelwithSelector(
+		namespaceSpec,
+		"dev",
+		"build-pipeline", // Name provided
+		selector,         // Selector also matches, but name should win
+		PrunerResourceTypePipelineRun,
+		PrunerFieldTypeTTLSecondsAfterFinished,
+	)
+
+	if result == nil {
+		t.Fatal("Expected non-nil result for name match")
+	}
+	if *result != 1800 {
+		t.Errorf("Expected TTL=1800 from name match, got %d", *result)
+	}
+	if identifiedBy != "identifiedBy_resource_name" {
+		t.Errorf("Expected identifiedBy='identifiedBy_resource_name', got '%s'", identifiedBy)
+	}
+}
+
+// TestGetFromPrunerConfigResourceLevelwithSelector_ANDLogic verifies that
+// both labels AND annotations must match when both are specified
+func TestGetFromPrunerConfigResourceLevelwithSelector_ANDLogic(t *testing.T) {
+	ttl1800 := int32(1800)
+
+	namespaceSpec := map[string]NamespaceSpec{
+		"dev": {
+			PipelineRuns: []ResourceSpec{
+				{
+					Selector: []SelectorSpec{
+						{
+							MatchLabels:      map[string]string{"app": "myapp"},
+							MatchAnnotations: map[string]string{"version": "v1"},
+						},
+					},
+					PrunerConfig: PrunerConfig{
+						TTLSecondsAfterFinished: &ttl1800,
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		selector   SelectorSpec
+		shouldFind bool
+	}{
+		{
+			name: "both labels and annotations match - should find",
+			selector: SelectorSpec{
+				MatchLabels:      map[string]string{"app": "myapp"},
+				MatchAnnotations: map[string]string{"version": "v1"},
+			},
+			shouldFind: true,
+		},
+		{
+			name: "only labels match - should NOT find",
+			selector: SelectorSpec{
+				MatchLabels: map[string]string{"app": "myapp"},
+			},
+			shouldFind: false,
+		},
+		{
+			name: "only annotations match - should NOT find",
+			selector: SelectorSpec{
+				MatchAnnotations: map[string]string{"version": "v1"},
+			},
+			shouldFind: false,
+		},
+		{
+			name: "labels match but annotations don't - should NOT find",
+			selector: SelectorSpec{
+				MatchLabels:      map[string]string{"app": "myapp"},
+				MatchAnnotations: map[string]string{"version": "v2"},
+			},
+			shouldFind: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, identifiedBy := getFromPrunerConfigResourceLevelwithSelector(
+				namespaceSpec,
+				"dev",
+				"", // No name, use selector
+				tt.selector,
+				PrunerResourceTypePipelineRun,
+				PrunerFieldTypeTTLSecondsAfterFinished,
+			)
+
+			if tt.shouldFind {
+				if result == nil {
+					t.Error("Expected to find result, but got nil")
+				} else if *result != 1800 {
+					t.Errorf("Expected TTL=1800, got %d", *result)
+				}
+				if identifiedBy != "identifiedBy_resource_selector" {
+					t.Errorf("Expected identifiedBy='identifiedBy_resource_selector', got '%s'", identifiedBy)
+				}
+			} else {
+				if result != nil {
+					t.Errorf("Expected nil result, but got %v", *result)
+				}
+				if identifiedBy != "" {
+					t.Errorf("Expected empty identifiedBy, got '%s'", identifiedBy)
+				}
+			}
+		})
+	}
+}
+
+// TestGetFromPrunerConfigResourceLevelwithSelector_NoMatchReturnsNil verifies that
+// when name is provided but doesn't match, nil is returned (no fallback to selectors)
+func TestGetFromPrunerConfigResourceLevelwithSelector_NoMatchReturnsNil(t *testing.T) {
+	ttl1800 := int32(1800)
+
+	namespaceSpec := map[string]NamespaceSpec{
+		"dev": {
+			PipelineRuns: []ResourceSpec{
+				{
+					Selector: []SelectorSpec{
+						{
+							MatchLabels: map[string]string{"app": "myapp"},
+						},
+					},
+					PrunerConfig: PrunerConfig{
+						TTLSecondsAfterFinished: &ttl1800,
+					},
+				},
+			},
+		},
+	}
+
+	selector := SelectorSpec{
+		MatchLabels: map[string]string{"app": "myapp"},
+	}
+
+	// Name provided but doesn't match - should return nil (no fallback to selector)
+	result, identifiedBy := getFromPrunerConfigResourceLevelwithSelector(
+		namespaceSpec,
+		"dev",
+		"non-existent-pipeline", // Name doesn't match any resource
+		selector,                // Selector would match, but should be ignored
+		PrunerResourceTypePipelineRun,
+		PrunerFieldTypeTTLSecondsAfterFinished,
+	)
+
+	if result != nil {
+		t.Errorf("Expected nil result for non-matching name, got %v", *result)
+	}
+	if identifiedBy != "" {
+		t.Errorf("Expected empty identifiedBy, got '%s'", identifiedBy)
+	}
+}
+
+// TestGetResourceFieldData_NamespaceConfigMapSelectors verifies that
+// EnforcedConfigLevelNamespace checks namespace ConfigMap selectors first
+func TestGetResourceFieldData_NamespaceConfigMapSelectors(t *testing.T) {
+	ttl1800 := int32(1800)
+	ttl3600 := int32(3600)
+	ttl7200 := int32(7200)
+
+	globalSpec := GlobalConfig{
+		PrunerConfig: PrunerConfig{
+			TTLSecondsAfterFinished: &ttl7200, // Global default
+		},
+	}
+
+	namespaceConfigMap := map[string]NamespaceSpec{
+		"dev": {
+			PipelineRuns: []ResourceSpec{
+				{
+					Selector: []SelectorSpec{
+						{
+							MatchLabels: map[string]string{"app": "myapp"},
+						},
+					},
+					PrunerConfig: PrunerConfig{
+						TTLSecondsAfterFinished: &ttl1800, // Namespace ConfigMap selector
+					},
+				},
+			},
+			PrunerConfig: PrunerConfig{
+				TTLSecondsAfterFinished: &ttl3600, // Namespace ConfigMap root
+			},
+		},
+	}
+
+	selector := SelectorSpec{
+		MatchLabels: map[string]string{"app": "myapp"},
+	}
+
+	// Should find selector match from namespace ConfigMap (ttl1800)
+	result, identifiedBy := getResourceFieldData(
+		globalSpec,
+		namespaceConfigMap,
+		"dev",
+		"", // No name
+		selector,
+		PrunerResourceTypePipelineRun,
+		PrunerFieldTypeTTLSecondsAfterFinished,
+		EnforcedConfigLevelNamespace,
+	)
+
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+	if *result != 1800 {
+		t.Errorf("Expected TTL=1800 from namespace ConfigMap selector, got %d", *result)
+	}
+	if identifiedBy != "identifiedBy_resource_selector" {
+		t.Errorf("Expected identifiedBy='identifiedBy_resource_selector', got '%s'", identifiedBy)
+	}
+}
+
+// TestGetResourceFieldData_GlobalConfigMapNoSelectors verifies that
+// EnforcedConfigLevelGlobal never uses selectors, only root-level fields
+func TestGetResourceFieldData_GlobalConfigMapNoSelectors(t *testing.T) {
+	ttl7200 := int32(7200)
+
+	globalSpec := GlobalConfig{
+		PrunerConfig: PrunerConfig{
+			TTLSecondsAfterFinished: &ttl7200, // Global default - should be used
+		},
+		Namespaces: map[string]NamespaceSpec{
+			"dev": {
+				// Even if there are selectors here, they should be ignored for EnforcedConfigLevelGlobal
+				PipelineRuns: []ResourceSpec{
+					{
+						Selector: []SelectorSpec{
+							{
+								MatchLabels: map[string]string{"app": "myapp"},
+							},
+						},
+						PrunerConfig: PrunerConfig{
+							TTLSecondsAfterFinished: int32Ptr(1800), // Should be ignored
+						},
+					},
+				},
+			},
+		},
+	}
+
+	selector := SelectorSpec{
+		MatchLabels: map[string]string{"app": "myapp"},
+	}
+
+	// EnforcedConfigLevelGlobal should use only global root, ignore all selectors
+	result, identifiedBy := getResourceFieldData(
+		globalSpec,
+		map[string]NamespaceSpec{},
+		"dev",
+		"",
+		selector,
+		PrunerResourceTypePipelineRun,
+		PrunerFieldTypeTTLSecondsAfterFinished,
+		EnforcedConfigLevelGlobal,
+	)
+
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+	if *result != 7200 {
+		t.Errorf("Expected TTL=7200 from global root (ignoring selectors), got %d", *result)
+	}
+	if identifiedBy != "identified_by_global" {
+		t.Errorf("Expected identifiedBy='identified_by_global', got '%s'", identifiedBy)
+	}
+}


### PR DESCRIPTION
# Changes

This pull request enforce the restriction that selectors (such as `matchLabels` and `matchAnnotations`) for resource grouping are only supported in namespace-level ConfigMaps, not in global ConfigMaps. It revises tutorials, validation docs, and sample configurations to reflect this behavior, adds new examples, and improves best practices guidance. These changes help users avoid misconfiguration and understand the correct usage patterns for Tekton Pruner resource grouping.

* Documentation now clearly states that selectors only work in namespace-level ConfigMaps (`tekton-pruner-namespace-spec`), and are ignored or rejected in global ConfigMaps. Examples and error messages are provided to illustrate invalid usage. 
* Validation docs and tutorials are updated to show that selector-based resource matching is only processed for namespace configs, and global ConfigMaps are for cluster-wide defaults only. 
* All selector-based configuration examples now use the correct namespace ConfigMap format (`ns-config`), and global ConfigMap examples remove selectors or clarify their limitations.
* New sample ConfigMaps are added for basic global configuration and global with inline namespace overrides, demonstrating best practices for both methods.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
This release introduces support for selector-based resource grouping using matchLabels and matchAnnotations in namespace-level ConfigMaps (tekton-pruner-namespace-spec).
This allows users to define pruning policies that apply automatically to specific PipelineRuns or TaskRuns based on labels and annotations.
```
/kind feature
