### PR TITLE
chore: add release pipeline and workflow

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -1,0 +1,190 @@
+name: Pruner Nightly Build
+
+"on":
+  schedule:
+    # Run at 03:00 UTC daily
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      kubernetes_version:
+        description: 'Kubernetes version to test with'
+        required: false
+        default: 'v1.33.x'
+      nightly_bucket:
+        description: 'Oracle Cloud bucket name for builds'
+        required: false
+        default: 'tekton-nightly'
+        type: string
+
+env:
+  KUBERNETES_VERSION: ${{ inputs.kubernetes_version || 'v1.33.x' }}
+  REGISTRY: ghcr.io
+  PACKAGE: github.com/${{ github.repository }}
+  BUCKET: ${{ inputs.nightly_bucket || 'tekton-nightly' }}
+  REPO_NAME: ${{ github.event.repository.name }}
+  IMAGE_REGISTRY_PATH: ${{ github.repository }}
+  IMAGE_REGISTRY_USER: tekton-robot
+
+jobs:
+  build:
+    name: Nightly Build (K8s ${{ inputs.kubernetes_version || 'v1.33.x' }})
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Generate version info
+        id: version
+        run: |
+          latest_sha=${{ github.sha }}
+          date_tag=$(date +v%Y%m%d-${latest_sha:0:7})
+          echo "version_tag=${date_tag}" >> "$GITHUB_OUTPUT"
+          echo "latest_sha=${latest_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Kind cluster
+        uses: chainguard-dev/actions/setup-kind@1b32103f5aa389c31ab0be75a8edc38d7e4750d8  # v1.5.7
+        with:
+          k8s-version: ${{ env.KUBERNETES_VERSION }}
+
+      - name: Set up Tekton
+        uses: tektoncd/actions/setup-tektoncd@dd92514472167b361de1c95fd31fc2ef83c282ec  # main
+        with:
+          pipeline_version: latest
+          setup_registry: "true"
+          patch_etc_hosts: "true"
+
+      - name: Configure Tekton Git Resolver
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
+        run: |
+          # Create Git authentication secret with proper Tekton annotations
+          kubectl create secret generic git-resolver-secret \
+            --from-literal=token="${GITHUB_TOKEN}" \
+            -n tekton-pipelines-resolvers || true
+
+          kubectl annotate secret git-resolver-secret \
+            tekton.dev/git-0=github.com \
+            -n tekton-pipelines-resolvers || true
+
+          kubectl create secret generic git-resolver-secret \
+            --from-literal=token="${GITHUB_TOKEN}" \
+            -n default || true
+
+          kubectl annotate secret git-resolver-secret \
+            tekton.dev/git-0=github.com \
+            -n default || true
+
+          kubectl patch configmap git-resolver-config -n tekton-pipelines-resolvers --patch='
+          data:
+            api-token-secret-name: "git-resolver-secret"
+            api-token-secret-key: "token"
+          ' || true
+
+          kubectl patch configmap feature-flags -n tekton-pipelines --patch='
+          data:
+            enable-cel-in-whenexpression: "true"
+          ' || true
+
+      - name: Apply Build Pipeline Definition
+        run: |
+          kustomize build tekton | kubectl apply -f -
+
+      - name: Create secrets, service account and PVC template
+        env:
+          OCI_API_KEY: ${{ secrets.OCI_API_KEY }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
+          IMAGE_REGISTRY_USER: ${{ env.IMAGE_REGISTRY_USER }}
+        run: |
+          # Create Oracle Cloud credentials secret for release bucket access
+          echo "${OCI_API_KEY}" > /tmp/oci_api_key.pem
+          echo "${OCI_FINGERPRINT}" > /tmp/fingerprint
+          echo "${OCI_TENANCY_OCID}" > /tmp/tenancy_ocid
+          echo "${OCI_USER_OCID}" > /tmp/user_ocid
+          echo "${OCI_REGION}" > /tmp/region
+
+          kubectl create secret generic release-secret \
+            --from-file=oci_api_key.pem=/tmp/oci_api_key.pem \
+            --from-file=fingerprint=/tmp/fingerprint \
+            --from-file=tenancy_ocid=/tmp/tenancy_ocid \
+            --from-file=user_ocid=/tmp/user_ocid \
+            --from-file=region=/tmp/region
+
+          rm -f /tmp/oci_api_key.pem /tmp/fingerprint /tmp/tenancy_ocid /tmp/user_ocid /tmp/region
+
+          # Create a Kubernetes secret for GHCR authentication.
+          # This version creates the secret with a custom key name `docker-config.json`
+          # (instead of the default `.dockerconfigjson`) to match what the publish task expects.
+          echo "${GHCR_TOKEN}" > /tmp/docker-config.json
+          kubectl create secret generic release-images-secret \
+            --from-file=docker-config.json=/tmp/docker-config.json
+          rm -f /tmp/docker-config.json
+
+          # Apply service account configuration with proper RBAC
+          kubectl apply -f tekton/account.yaml
+
+          cat > workspace-template.yaml << EOF
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+          EOF
+
+      - name: Start Tekton Build Pipeline
+        run: |
+          set -euo pipefail  # Exit on any error, undefined variables, or pipe failures
+
+          echo "Starting Tekton pipeline..."
+
+          PIPELINE_RUN=$(tkn pipeline start pipeline-release \
+            --serviceaccount=release-right-meow \
+            --param package="${{ env.PACKAGE }}" \
+            --param repoName="${{ env.REPO_NAME }}" \
+            --param gitRevision="${{ steps.version.outputs.latest_sha }}" \
+            --param versionTag="${{ steps.version.outputs.version_tag }}" \
+            --param releaseBucket="${{ env.BUCKET }}" \
+            --param imageRegistry=${{ env.REGISTRY }} \
+            --param imageRegistryPath="${{ env.IMAGE_REGISTRY_PATH }}" \
+            --param imageRegistryUser="${{ env.IMAGE_REGISTRY_USER }}" \
+            --param imageRegistryRegions="" \
+            --param buildPlatforms="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le" \
+            --param publishPlatforms="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64" \
+            --param koExtraArgs="" \
+            --param serviceAccountImagesPath=docker-config.json \
+            --param releaseAsLatest="true" \
+            --param runTests="false" \
+            --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml \
+            --workspace name=release-secret,secret=release-secret \
+            --workspace name=release-images-secret,secret=release-images-secret \
+            --tasks-timeout 2h \
+            --pipeline-timeout 3h \
+            --output name) || {
+            echo "Failed to start Tekton pipeline!"
+            exit 1
+          }
+
+          echo "Pipeline started: ${PIPELINE_RUN}"
+          tkn pipelinerun logs "${PIPELINE_RUN}" -f
+
+          # Check if pipeline succeeded
+          tkn pipelinerun describe "${PIPELINE_RUN}" --output jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' | grep -q "True" || {
+            echo "Pipeline failed!"
+            tkn pipelinerun describe "${PIPELINE_RUN}"
+            exit 1
+          }
+
+          echo "✅ Pipeline Run completed successfully!"

--- a/tekton/account.yaml
+++ b/tekton/account.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-right-meow
+secrets:
+- name: release-secret
+- name: git-resolver-secret
+- name: release-images-secret
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-api-secret
+  annotations:
+    kubernetes.io/service-account.name: release-right-meow
+type: kubernetes.io/service-account-token
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-role
+rules:
+- apiGroups: [""]
+  resources: ["services", "configmaps", "secrets"]
+  verbs: ["get", "create", "update", "patch", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "create", "update", "patch", "list"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelines", "pipelineruns", "tasks", "taskruns"]
+  verbs: ["get", "create", "update", "patch", "list"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline-role
+subjects:
+- kind: ServiceAccount
+  name: release-right-meow

--- a/tekton/kustomization.yaml
+++ b/tekton/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - account.yaml
+  - publish.yaml
+  - release-pipeline.yaml

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -1,0 +1,274 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: publish-release
+  annotations:
+    chains.tekton.dev/transparency-upload: "true"
+spec:
+  params:
+    - name: package
+      description: package to release (e.g. github.com/<org>/<project>)
+      default: github.com/tektoncd/pipeline
+    - name: images
+      description: List of cmd/* paths to be published as images
+      default: "controller webhook"
+    - name: koExtraArgs
+      description: Extra args to be passed to ko
+      default: "--preserve-import-paths"
+    - name: versionTag
+      description: The version, vX.Y.Z for stable, vYYYYMMDD-abc1234 for nightly that the artifacts should be tagged with (including `v`).
+    - name: imageRegistry
+      description: The target image registry
+      default: ghcr.io
+    - name: imageRegistryPath
+      description: The path (project) in the image registry
+    - name: imageRegistryRegions
+      description: The target image registry regions
+      default: ""
+    - name: imageRegistryUser
+      description: Username to be used to login to the container registry
+      default: "_json_key"
+    - name: releaseAsLatest
+      description: Whether to tag and publish this release as Pipelines latest
+      default: "true"
+    - name: platforms
+      description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    - name: serviceAccountPath
+      description: The name of the service account path within the release-secret workspace
+  workspaces:
+    - name: source
+      description: >-
+        The workspace where the repo has been cloned. This should ideally
+        be /go/src/$(params.package) however that is not possible today,
+        see https://github.com/tektoncd/pipeline/issues/3786. To use this
+        task on a fork of pipeline change the mountPath below
+      mountPath: /go/src/github.com/tektoncd/pipeline
+    - name: release-secret
+      description: The secret that contains a service account authorized to push to the imageRegistry and to the output bucket
+    - name: output
+      description: The release YAML will be written to this workspace
+  stepTemplate:
+    env:
+      - name: "PROJECT_ROOT"
+        value: "$(workspaces.source.path)"
+      - name: CONTAINER_REGISTRY_CREDENTIALS
+        value: "$(workspaces.release-secret.path)/$(params.serviceAccountPath)"
+      - name: CONTAINER_REGISTRY
+        value: "$(params.imageRegistry)/$(params.imageRegistryPath)"
+      - name: IMAGE_REGISTRY_PATH
+        value: "$(params.imageRegistryPath)"
+      - name: CONTAINER_REGISTRY_USER
+        value: "$(params.imageRegistryUser)"
+      - name: REGIONS
+        value: "$(params.imageRegistryRegions)"
+      - name: OUTPUT_RELEASE_DIR
+        value: "$(workspaces.output.path)/$(params.versionTag)"
+      - name: KO_EXTRA_ARGS
+        value: "$(params.koExtraArgs)"
+  results:
+  # IMAGES result is picked up by Tekton Chains to sign the release.
+  # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
+  - name: IMAGES
+  steps:
+
+  - name: container-registry-auth
+    image: cgr.dev/chainguard/crane:latest-dev@sha256:81a5126672ca23e7706f2c838c841790274641d50c5ff852542062cefde0f36a
+    script: |
+      #!/bin/sh
+      set -ex
+
+      # Login to the container registry
+      DOCKER_CONFIG=$(cat ${CONTAINER_REGISTRY_CREDENTIALS} | \
+        crane auth login -u ${CONTAINER_REGISTRY_USER} --password-stdin $(params.imageRegistry) 2>&1 | \
+        sed -n 's,^.*logged in via \(.*\)$,\1,p')
+
+      # Auth with account credentials for all regions.
+      for region in ${REGIONS}
+      do
+        HOSTNAME=${region}.$(params.imageRegistry)
+        cat ${CONTAINER_REGISTRY_CREDENTIALS} | crane auth login -u ${CONTAINER_REGISTRY_USER} --password-stdin ${HOSTNAME}
+      done
+      cp ${DOCKER_CONFIG} /workspace/docker-config.json
+
+  - name: create-ko-yaml
+    image: cgr.dev/chainguard/go:latest-dev@sha256:7be705886a38c294e64e701bd2c257990e30e44544c966eb29c6955bc8205798
+    script: |
+      #!/bin/sh
+      set -ex
+
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
+
+      # Change to directory with vendor/
+      cd ${PROJECT_ROOT}
+
+      # Copy the repository's .ko.yaml as the base configuration
+      cp ${PROJECT_ROOT}/.ko.yaml /workspace/.ko.yaml
+
+      COMBINED_BASE_IMAGE_BASE=${CONTAINER_REGISTRY}
+      # If the IMAGE_REGISTRY_PATH does not already includes the package, add it
+      # Package looks like github.com/<org>/<repo>
+      # Path may look like "tekton-releases" or "tektoncd/pipeline"
+      if [[ ! "$(params.package)" == "github.com/${IMAGE_REGISTRY_PATH}" ]]; then
+        COMBINED_BASE_IMAGE_BASE=${COMBINED_BASE_IMAGE_BASE}/${IMAGE_REGISTRY_PATH}
+      fi
+
+      # Combine Distroless with a Windows base image, used for the entrypoint image.
+      # Distroless is pinned to the last version based on Alpine 3.18. Newer versions are based on Alpine 3.19_alpha20230901.
+      COMBINED_BASE_IMAGE=$(go run ./vendor/github.com/tektoncd/plumbing/cmd/combine/main.go \
+        cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7 \
+        mcr.microsoft.com/windows/nanoserver:ltsc2019 \
+        mcr.microsoft.com/windows/nanoserver:ltsc2022 \
+        ${COMBINED_BASE_IMAGE_BASE}/combined-base-image:latest)
+
+      # Replace :latest references with the actual combined base image digest
+      sed -i "s|ghcr.io/tektoncd/pruner/github.com/tektoncd/pruner/combined-base-image:latest|${COMBINED_BASE_IMAGE}|g" /workspace/.ko.yaml
+
+      cat /workspace/.ko.yaml
+
+  - name: run-ko
+    image: ghcr.io/tektoncd/plumbing/ko@sha256:990ec7fc709567e0d26fa40788a040b97598343d2fcb7252751316e34f31c4cc
+    env:
+    - name: KO_DOCKER_REPO
+      value: $(params.imageRegistry)/$(params.imageRegistryPath)
+    - name: GOFLAGS
+      value: "-mod=vendor"
+    script: |
+      #!/usr/bin/env sh
+      set -ex
+
+      # Fix Git ownership issue for the repository directory
+      git config --global --add safe.directory ${PROJECT_ROOT}
+
+      # Use the generated `.ko.yaml`
+      export KO_CONFIG_PATH=/workspace
+      cat ${KO_CONFIG_PATH}/.ko.yaml
+
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
+
+      # Change to directory with our .ko.yaml
+      cd ${PROJECT_ROOT}
+
+      # For each cmd/* directory, include a full gzipped tar of all source in
+      # vendor/. This is overkill. Some deps' licenses require the source to be
+      # included in the container image when they're used as a dependency.
+      # Rather than trying to determine which deps have this requirement (and
+      # probably get it wrong), we'll just targz up the whole vendor tree and
+      # include it. As of 9/20/2019, this amounts to about 11MB of additional
+      # data in each image.
+      TMPDIR=$(mktemp -d)
+      tar cfz ${TMPDIR}/source.tar.gz vendor/
+      for d in cmd/*; do
+        if [ -d ${d}/kodata/ ]; then
+          ln -s ${TMPDIR}/source.tar.gz ${d}/kodata/
+        fi
+      done
+
+      # Publish images and create release.yaml
+      mkdir -p $OUTPUT_RELEASE_DIR
+
+      # Make a local git tag to make git status happy :)
+      # The real "tagging" will happen with the "create-release" pipeline.
+      git tag $(params.versionTag)
+
+      ko resolve \
+        --image-label=org.opencontainers.image.source=https://$(params.package) \
+        --platform=$(params.platforms) \
+        -t $(params.versionTag) \
+        -R ${KO_EXTRA_ARGS} \
+        -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.yaml
+      # Publish images and create release.notags.yaml
+      # This is useful if your container runtime doesn't support the `image-reference:tag@digest` notation
+      # This is currently the case for `cri-o` (and most likely others)
+      ko resolve \
+        --image-label=org.opencontainers.image.source=https://$(params.package) \
+        --platform=$(params.platforms) \
+        -R ${KO_EXTRA_ARGS} \
+        -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml
+
+      # Rewrite "devel" to params.versionTag
+      sed -i -e 's/\(pruner.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/release.yaml
+      sed -i -e 's/\(pruner.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/release.notags.yaml
+
+  - name: koparse
+    image: ghcr.io/tektoncd/plumbing/koparse@sha256:7ea59fefb312a512973f743298c17217ca96f0e9303f8d40ebbf2d27ceb9f21e
+    script: |
+      set -ex
+
+      # Find "--preserve-import-paths" in a list of args
+      function find_preserve_import_path() {
+        for arg in $@; do
+          if [[ "$arg" == "--preserve-import-paths" ]]; then
+            return 0
+          fi
+        done
+        return 1
+      }
+
+      # If "--preserve-import-paths" is used, include "package" in the expected path
+      find_preserve_import_path \
+        $(echo $KO_EXTRA_ARGS) && \
+        PRESERVE_IMPORT_PATH="--preserve-path" || \
+        PRESERVE_IMPORT_PATH="--no-preserve-path"
+
+      for cmd in $(params.images)
+      do
+        IMAGES="${IMAGES} $(params.package)/cmd/${cmd}:$(params.versionTag)"
+      done
+
+      # Parse the built images from the release.yaml generated by ko
+      koparse \
+        --path $OUTPUT_RELEASE_DIR/release.yaml \
+        --base $(params.package) \
+        --container-registry ${CONTAINER_REGISTRY} \
+        --images ${IMAGES} \
+        ${PRESERVE_IMPORT_PATH} > /workspace/built_images
+
+  - name: tag-images
+    image: cgr.dev/chainguard/crane:latest-dev@sha256:81a5126672ca23e7706f2c838c841790274641d50c5ff852542062cefde0f36a
+    script: |
+      #!/bin/sh
+      set -ex
+
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
+
+      # Tag the images and put them in all the regions
+      for IMAGE in $(cat /workspace/built_images)
+      do
+        IMAGE_WITHOUT_SHA=${IMAGE%%@*}
+        IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
+        IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
+
+        echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+
+        if [[ "$(params.releaseAsLatest)" == "true" ]]
+        then
+          crane cp ${IMAGE_WITH_SHA} ${IMAGE_WITHOUT_SHA_AND_TAG}:latest
+        fi
+
+        for REGION in ${REGIONS}
+        do
+          if [[ "$(params.releaseAsLatest)" == "true" ]]
+          then
+            for TAG in "latest" $(params.versionTag)
+            do
+              crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+            done
+          else
+            TAG="$(params.versionTag)"
+            crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+          fi
+          # Until we are able to store larger results, we cannot include the
+          # regional copies of the images in the result - see https://github.com/tektoncd/pipeline/issues/4282
+          # echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+        done
+      done

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -1,0 +1,306 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipeline-release
+spec:
+  params:
+    - name: package
+      description: package to release
+      default: github.com/tektoncd/pruner
+    - name: repoName
+      description: repository name (e.g., pipeline, triggers, etc.)
+      default: pruner
+    - name: gitRevision
+      description: the git revision to release
+    - name: imageRegistry
+      description: The target image registry
+      default: ghcr.io
+    - name: imageRegistryPath
+      description: The path (project) in the image registry
+      default: "tekton-releases-nightly"  # Will be overridden based on releaseMode
+    - name: imageRegistryRegions
+      description: The target image registry regions
+      default: ""  # Empty for GHCR, "us eu asia" for GCR
+    - name: imageRegistryUser
+      description: The user for the image registry credentials
+      default: _json_key
+    - name: versionTag
+      description: Version tag (vX.Y.Z for stable, vYYYYMMDD-abc1234 for nightly)
+    - name: releaseBucket
+      description: bucket where the release is stored. The bucket must be project specific.
+      default: "tekton-nightly"  # Will be overridden based on releaseMode
+    - name: releaseAsLatest
+      description: Whether to tag and publish this release as latest
+      default: "false"  # Will be overridden based on releaseMode
+    - name: buildPlatforms
+      description: Platforms to build images for (e.g. linux/amd64,linux/arm64)
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+    - name: publishPlatforms
+      description: |
+        Platforms to publish images for (e.g. linux/amd64,linux/arm64,windows/amd64). This
+        can differ from buildPlatforms due to the fact that a windows-compatible base image
+        is constructed for the publishing phase.)
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    - name: koExtraArgs
+      description: Extra args to be passed to ko
+      default: "--preserve-import-paths"
+    - name: serviceAccountImagesPath
+      description: The path to the service account file or credentials within the release-images-secret workspace
+    - name: runTests
+      description: If set to something other than "true", skip the build and test tasks
+      default: "true"
+  workspaces:
+    - name: workarea
+      description: The workspace where the repo will be cloned.
+    - name: release-secret
+      description: The secret that contains auth credentials to push to the output bucket
+    - name: release-images-secret
+      description: The secret that contains a service account authorized to push to the imageRegistry
+  results:
+    - name: commit-sha
+      description: the sha of the commit that was released
+      value: $(tasks.git-clone.results.commit)
+    - name: release-file
+      description: the URL of the release file
+      value: $(tasks.report-bucket.results.release)
+    - name: release-file-no-tag
+      description: the URL of the release file
+      value: $(tasks.report-bucket.results.release-no-tag)
+  tasks:
+    - name: git-clone
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
+      workspaces:
+        - name: output
+          workspace: workarea
+          subPath: git
+      params:
+        - name: url
+          value: https://$(params.package)
+        - name: revision
+          value: $(params.gitRevision)
+
+    - name: precheck
+      runAfter: [git-clone]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
+          - name: pathInRepo
+            value: tekton/resources/release/base/prerelease_checks.yaml
+      params:
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: releaseBucket
+          value: $(params.releaseBucket)
+      workspaces:
+        - name: source-to-release
+          workspace: workarea
+          subPath: git
+
+    - name: unit-tests
+      runAfter: [precheck]
+      when:
+        - cel: "'$(params.runTests)' == 'true'"
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/golang-test:0.2
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
+      params:
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: "./..."
+        - name: flags
+          value: -v -mod=vendor
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+
+    - name: build
+      runAfter: [precheck]
+      when:
+        - cel: "'$(params.runTests)' == 'true'"
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/golang-build:0.3
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
+      params:
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: ./cmd/...
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+
+    - name: publish-images
+      runAfter: [unit-tests, build]
+      taskRef:
+        resolver: git
+        params:
+          - name: repo
+            value: pruner
+          - name: org
+            value: tektoncd
+          - name: revision
+            value: $(params.gitRevision)
+          - name: pathInRepo
+            value: tekton/publish.yaml
+      params:
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: imageRegistry
+          value: $(params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(params.imageRegistryPath)
+        - name: imageRegistryUser
+          value: $(params.imageRegistryUser)
+        - name: imageRegistryRegions
+          value: $(params.imageRegistryRegions)
+        - name: releaseAsLatest
+          value: $(params.releaseAsLatest)
+        - name: serviceAccountPath
+          value: $(params.serviceAccountImagesPath)
+        - name: platforms
+          value: $(params.publishPlatforms)
+        - name: koExtraArgs
+          value: $(params.koExtraArgs)
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+        - name: output
+          workspace: workarea
+          subPath: bucket
+        - name: release-secret
+          workspace: release-images-secret
+      timeout: 3h
+
+    - name: publish-to-bucket
+      runAfter: [publish-images]
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+          - name: name
+            value: oracle-cloud-storage-upload
+          - name: kind
+            value: task
+      workspaces:
+        - name: credentials
+          workspace: release-secret
+        - name: source
+          workspace: workarea
+          subPath: bucket
+      params:
+        - name: path
+          value: $(params.versionTag)
+        - name: bucketName
+          value: $(params.releaseBucket)
+        - name: objectPrefix
+          value: $(params.repoName)/previous/$(params.versionTag)/
+        - name: replaceExistingFiles
+          value: "true"
+        - name: recursive
+          value: "true"
+
+    - name: publish-to-bucket-latest
+      runAfter: [publish-images]
+      when:
+        - input: "$(params.releaseAsLatest)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+          - name: name
+            value: oracle-cloud-storage-upload
+          - name: kind
+            value: task
+      workspaces:
+        - name: credentials
+          workspace: release-secret
+        - name: source
+          workspace: workarea
+          subPath: bucket
+      params:
+        - name: path
+          value: $(params.versionTag)
+        - name: bucketName
+          value: $(params.releaseBucket)
+        - name: objectPrefix
+          value: $(params.repoName)/latest/
+        - name: replaceExistingFiles
+          value: "true"
+        - name: recursive
+          value: "true"
+        - name: deleteExtraFiles
+          value: "true"  # Uses sync to copy content into latest
+
+    - name: report-bucket
+      runAfter: [publish-to-bucket]
+      params:
+        - name: releaseBucket
+          value: $(params.releaseBucket)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: repoName
+          value: $(params.repoName)
+      taskSpec:
+        params:
+          - name: releaseBucket
+          - name: versionTag
+          - name: repoName
+        results:
+          - name: release
+            description: The full URL of the release file in the bucket
+          - name: release-no-tag
+            description: The full URL of the release file (no tag) in the bucket
+        steps:
+          - name: create-results
+            image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
+            env:
+              - name: RELEASE_BUCKET
+                value: $(params.releaseBucket)
+              - name: VERSION_TAG
+                value: $(params.versionTag)
+              - name: REPO_NAME
+                value: $(params.repoName)
+            script: |
+              # Oracle Cloud Storage: Construct public URL
+              # Format: https://infra.tekton.dev/<releaseBucket>/<repoName>/previous/<versionTag>
+              BASE_URL="https://infra.tekton.dev/${RELEASE_BUCKET}/${REPO_NAME}/previous/${VERSION_TAG}"
+
+              echo "${BASE_URL}/release.yaml" > $(results.release.path)
+              echo "${BASE_URL}/release.notag.yaml" > $(results.release-no-tag.path)


### PR DESCRIPTION
# Changes

This pull request introduces a nightly build pipeline for pruner repo using GitHub Actions and Tekton Pipelines, with full Kubernetes RBAC setup and a custom publish task for container images. The changes automate nightly builds, configure necessary secrets and service accounts, and define a Tekton task for publishing multi-platform container images to a registry and Oracle Cloud bucket.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
