### PR TITLE
fix: enhance release docs and pipeline definitions

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -133,6 +133,7 @@ jobs:
           rm -f /tmp/docker-config.json
 
           # Apply service account configuration with proper RBAC
+          # NOTE: Adding this to kustomize might impact main release pipeline. so better to keep this step separate for nightly builds
           kubectl apply -f tekton/account.yaml
 
           cat > workspace-template.yaml << EOF
@@ -150,7 +151,7 @@ jobs:
 
           echo "Starting Tekton pipeline..."
 
-          PIPELINE_RUN=$(tkn pipeline start pipeline-release \
+          PIPELINE_RUN=$(tkn pipeline start pruner-release \
             --serviceaccount=release-right-meow \
             --param package="${{ env.PACKAGE }}" \
             --param repoName="${{ env.REPO_NAME }}" \

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -1,0 +1,26 @@
+# Tekton Repo CI/CD
+
+_Why does Tekton pruner have a folder called `tekton`? Cuz we think it would
+be cool if the `tekton` folder were the place to look for CI/CD logic similar to other tektoncd org
+repos!_
+
+We use Tekton Pipelines to build, test and release Tekton Pruner!
+
+This directory contains the
+[`Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md) and
+[`Pipelines`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md)
+that we use.
+
+The Pipelines and Tasks in this folder are used for:
+
+1. [Manually creating official releases from the official cluster](#create-an-official-release)
+
+To start from scratch and use these Pipelines and Tasks:
+
+1. [Install Tekton](https://github.com/tektoncd/pipeline/blob/master/tekton/README.md#install-tekton)
+1. [Setup the Tasks and Pipelines](https://github.com/tektoncd/pipeline/blob/master/tekton/README.md#install-tasks-and-pipelines)
+1. [Create the required service account + secrets](https://github.com/tektoncd/pipeline/blob/master/tekton/README.md#service-account-and-secrets)
+
+## Create an official release
+
+To create an official release, follows the steps in the [release-cheat-sheet](./release-cheat-sheet.md)

--- a/tekton/kustomization.yaml
+++ b/tekton/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - account.yaml
   - publish.yaml
   - release-pipeline.yaml

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -1,14 +1,14 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: publish-release
+  name: publish-pruner-release
   annotations:
     chains.tekton.dev/transparency-upload: "true"
 spec:
   params:
     - name: package
       description: package to release (e.g. github.com/<org>/<project>)
-      default: github.com/tektoncd/pipeline
+      default: github.com/tektoncd/pruner
     - name: images
       description: List of cmd/* paths to be published as images
       default: "controller webhook"
@@ -29,7 +29,7 @@ spec:
       description: Username to be used to login to the container registry
       default: "_json_key"
     - name: releaseAsLatest
-      description: Whether to tag and publish this release as Pipelines latest
+      description: Whether to tag and publish this release as Pruner latest
       default: "true"
     - name: platforms
       description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
@@ -43,7 +43,7 @@ spec:
         be /go/src/$(params.package) however that is not possible today,
         see https://github.com/tektoncd/pipeline/issues/3786. To use this
         task on a fork of pipeline change the mountPath below
-      mountPath: /go/src/github.com/tektoncd/pipeline
+      mountPath: /go/src/github.com/tektoncd/pruner
     - name: release-secret
       description: The secret that contains a service account authorized to push to the imageRegistry and to the output bucket
     - name: output

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -1,0 +1,185 @@
+# Tekton Pruner Official Release Cheat Sheet
+
+These steps provide a no-frills guide to performing an official release
+of Tekton Pruner. To follow these steps you'll need a checkout of
+the pruner repo, a terminal window and a text editor.
+
+1. [Setup a context to connect to the dogfooding cluster](#setup-dogfooding-context) if you haven't already.
+
+1. `cd` to root of Pruner git checkout.
+
+1. Make sure the release `Pipeline` is up-to-date on the cluster.
+
+   - [pruner-release](https://github.com/tektoncd/pruner/blob/main/tekton/release-pipeline.yaml)
+     ```shell script
+     kubectl apply -f tekton/release-pipeline.yaml
+     ```
+
+1. Select the commit you would like to build the release from, most likely the
+   most recent commit at https://github.com/tektoncd/pruner/commits/main
+   and note the commit's hash.
+
+1. Create environment variables for bash scripts in later steps.
+
+    ```bash
+    VERSION_TAG=# UPDATE THIS. Example: v0.6.2
+    PRUNER_RELEASE_GIT_SHA=# SHA of the release to be released
+    ```
+
+1. Confirm commit SHA matches what you want to release.
+
+    ```bash
+    git show $PRUNER_RELEASE_GIT_SHA
+    ```
+
+1. Create a workspace template file:
+
+   ```bash
+   cat <<EOF > workspace-template.yaml
+   spec:
+     accessModes:
+     - ReadWriteOnce
+     resources:
+       requests:
+         storage: 1Gi
+   EOF
+   ```
+
+1. Execute the release pipeline.
+
+    **If you are back-porting include this flag: `--param=releaseAsLatest="false"`**
+
+    ```bash
+    tkn --context dogfooding pipeline start pruner-release \
+      --param package=github.com/tektoncd/pruner \
+      --param repoName=pruner
+      --param imageRegistry=ghcr.io \
+      --param imageRegistryPath=tektoncd/pruner \
+      --param imageRegistryRegions="" \
+      --param imageRegistryUser=tekton-robot \
+      --param gitRevision="${PRUNER_RELEASE_GIT_SHA}" \
+      --param versionTag="${VERSION_TAG}" \
+      --param serviceAccountImagesPath=credentials \
+      --param releaseBucket=tekton-releases \
+      --param koExtraArgs="" \
+      --workspace name=release-secret,secret=oci-release-secret \
+      --workspace name=release-images-secret,secret=ghcr-creds \
+      --workspace name=workarea,volumeClaimTemplateFile=workspace-template.yaml
+    ```
+
+1. Watch logs of pruner-release.
+
+1. Once the pipeline run is complete, check its results:
+
+   ```bash
+   tkn --context dogfooding pr describe <pipeline-run-name>
+
+   (...)
+   📝 Results
+
+   NAME                    VALUE
+   commit-sha                 6ea31d92a97420d4b7af94745c45b02447ceaa19
+   release-file               https://infra.tekton.dev/tekton-releases/pruner/previous/v0.13.0/release.yaml
+   release-file-no-tag        https://infra.tekton.dev/tekton-releases/pruner/previous/v0.13.0/release.notag.yaml
+
+   (...)
+   ```
+
+   The `commit-sha` should match `$PRUNER_RELEASE_GIT_SHA`.
+   The two URLs can be opened in the browser or via `curl` to download the release manifests.
+
+1. The YAMLs are now released! Anyone installing Tekton pruner will now get the new version. Time to create a new GitHub release announcement:
+
+1. Create additional environment variables
+
+    ```bash
+    PRUNER_OLD_VERSION=# Example: v0.11.1
+    TEKTON_PACKAGE=tektoncd/pruner
+    ```
+
+1. Find the Rekor UUID for the release
+
+    ```bash
+    RELEASE_FILE=https://infra.tekton.dev/tekton-releases/pruner/previous/${VERSION_TAG}/release.yaml
+    CONTROLLER_IMAGE_SHA=$(curl $RELEASE_FILE | sed -n 's/"//g;s/.*ghcr\.io.*controller.*@//p;')
+    REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
+    echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
+    ```
+
+1. Execute the Draft Release task.
+
+    ```bash
+    tkn --context dogfooding pipeline start \
+        --workspace name=shared,volumeClaimTemplateFile=workspace-template.yaml \
+        --workspace name=credentials,secret=oci-release-secret \
+        -p package="${TEKTON_PACKAGE}" \
+        -p git-revision="${PRUNER_RELEASE_GIT_SHA}" \
+        -p release-tag="${VERSION_TAG}" \
+        -p previous-release-tag="${PRUNER_OLD_VERSION}" \
+        -p release-name="Tekton Pruner" \
+        -p bucket="tekton-releases" \
+        -p rekor-uuid="$REKOR_UUID" \
+        release-draft
+    ```
+
+1. Watch logs of create-draft-release. On successful completion, a URL will be logged. Visit that URL and look through the release notes.
+   
+1. Manually add upgrade and deprecation notices based on the generated release notes.  Double-check that the list of commits here matches your expectations
+for the release. You might need to remove incorrect commits or copy/paste commits
+from the release branch. Refer to previous releases to confirm the expected format.
+
+1. Un-check the "This is a pre-release" checkbox since you're making a legit for-reals release!
+
+1. Publish the GitHub release once all notes are correct and in order.
+
+1. Edit `releases.md` on the `main` branch, add an entry for the release.
+   - In case of a patch release, replace the latest release with the new one,
+     including links to docs and examples. Append the new release to the list
+     of patch releases as well.
+   - In case of a minor or major release, add a new entry for the
+     release, including links to docs and example
+   - Check if any release is EOL, if so move it to the "End of Life Releases"
+     section
+
+1. Push & make PR for updated `releases.md`
+
+1. Test release that you just made against your own cluster (note `--context my-dev-cluster`):
+
+    ```bash
+    # Test latest
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/pruner/latest/release.yaml
+    ```
+
+    ```bash
+    # Test backport
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/pruner/previous/v0.12.1/release.yaml
+    ```
+
+1. For major releases, the [website sync configuration](https://github.com/tektoncd/website/blob/main/sync/config/pruner.yaml)
+   to include the new release.
+
+1. Announce the release in Slack channels #general, #pruner and #announcements.
+
+Congratulations, you're done!
+
+## Setup dogfooding context
+
+1. Configure `kubectl` to connect to
+   [the dogfooding cluster](https://github.com/tektoncd/plumbing/blob/main/docs/dogfooding.md):
+
+    ```bash
+    oci ce cluster create-kubeconfig --cluster-id <CLUSTER-OCID> --file $HOME/.kube/config --region <CLUSTER-REGION> --token-version 2.0.0  --kube-endpoint PUBLIC_ENDPOINT
+    ```
+
+1. Give [the context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
+   a short memorable name such as `dogfooding`:
+
+   ```bash
+   kubectl config rename-context <REPLACE-WITH-NAME-FROM-CONFIG-CONTEXT> dogfooding
+   ```
+
+## Important: Switch `kubectl` back to your own cluster by default.
+
+```bash
+kubectl config use-context my-dev-cluster
+```

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: pipeline-release
+  name: pruner-release
 spec:
   params:
     - name: package
@@ -266,7 +266,7 @@ spec:
         - name: recursive
           value: "true"
         - name: deleteExtraFiles
-          value: "true"  # Uses sync to copy content into latest
+          value: "true"
 
     - name: report-bucket
       runAfter: [publish-to-bucket]


### PR DESCRIPTION
# Changes

This pull request updates the Tekton CI/CD configuration and documentation to support official releases for the Tekton Pruner project. The changes primarily rename and tailor pipeline resources for Pruner, add comprehensive release instructions, and clarify resource management for nightly builds.

Key changes include:

* Renamed pipeline and tasks from generic or "pipeline" names to Pruner-specific names in `tekton/release-pipeline.yaml` and `tekton/publish.yaml`
* Added a new `tekton/README.md` explaining the CI/CD setup and how to use Tekton Pipelines for Pruner.
* Introduced a detailed `tekton/release-cheat-sheet.md` with step-by-step instructions for performing official Pruner releases.
* Updated the nightly build GitHub Actions workflow to use the Pruner-specific pipeline and clarified why certain RBAC steps are kept separate
* Removed `account.yaml` from `tekton/kustomization.yaml` to avoid affecting the main release pipeline, ensuring it is only applied where needed.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
