### PR TITLE
fix: update base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,7 +1,4 @@
-defaultBaseImage: gcr.io/distroless/static:nonroot
-baseImageOverrides:
-  github.com/tektoncd/pruner/cmd/controller: registry.access.redhat.com/ubi9/ubi-minimal
-  github.com/tektoncd/pruner/cmd/webhook: registry.access.redhat.com/ubi9/ubi-minimal
+defaultBaseImage: cgr.dev/chainguard/static:latest
 
 builds:
   - id: ko


### PR DESCRIPTION
# Changes

This pull request updates the `defaultBaseImage` to use `cgr.dev/chainguard/static:latest` instead of `gcr.io/distroless/static:nonroot`, and removed the previous `baseImageOverrides` for components.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind misc