### PR TITLE
fix: webhook container to use correct configmap names

### DIFF
--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -64,3 +64,4 @@ data:
   # Log level overrides
   # Changes are be picked up immediately.
   loglevel.tekton-pruner-controller: "info"
+  loglevel.pruner-webhook: "info"

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -49,11 +49,11 @@ spec:
                   fieldPath: metadata.namespace
             # Logging configuration
             - name: CONFIG_LOGGING_NAME
-              value: config-logging
+              value: config-logging-tekton-pruner
             - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
+              value: config-observability-tekton-pruner
             - name: METRICS_DOMAIN
-              value: tekton.dev/pruner
+              value: pruner.tekton.dev
             # Webhook configuration
             - name: WEBHOOK_PORT
               value: "8443"


### PR DESCRIPTION
# Changes

This pull request updates logging and configuration settings listed below:
* Changed the logging configuration reference for the pruner webhook to use `config-logging-tekton-pruner` instead of the shared `config-logging` value in `config/webhook.yaml`.
* Changed the observability configuration reference for the pruner webhook to use `config-observability-tekton-pruner` instead of the shared `config-observability` value in `config/webhook.yaml`.
* Added a specific log level override for `pruner-webhook` in `config/config-logging.yaml`.
* Updated the metrics domain for the pruner webhook from `tekton.dev/pruner` to `pruner.tekton.dev` in `config/webhook.yaml`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind fix