### PR TITLE
fix: system limit violations in config

### DIFF
--- a/docs/tutorials/sample-configMaps/01-basic-global.yaml
+++ b/docs/tutorials/sample-configMaps/01-basic-global.yaml
@@ -14,5 +14,5 @@ data:
   global-config: |
     enforcedConfigLevel: global
     ttlSecondsAfterFinished: 3600
-    successfulHistoryLimit: 5
+    successfulHistoryLimit: 50
     failedHistoryLimit: 3

--- a/docs/tutorials/sample-configMaps/02-global-with-namespace-inline.yaml
+++ b/docs/tutorials/sample-configMaps/02-global-with-namespace-inline.yaml
@@ -15,18 +15,18 @@ data:
     enforcedConfigLevel: namespace
     
     ttlSecondsAfterFinished: 604800
-    successfulHistoryLimit: 5
-    failedHistoryLimit: 5
+    successfulHistoryLimit: 50
+    failedHistoryLimit: 50
     
     namespaces:
       development:
         ttlSecondsAfterFinished: 300
-        successfulHistoryLimit: 3
-        failedHistoryLimit: 2
+        successfulHistoryLimit: 30
+        failedHistoryLimit: 20
       
       staging:
         ttlSecondsAfterFinished: 86400
-        successfulHistoryLimit: 10
+        successfulHistoryLimit: 25
         failedHistoryLimit: 5
       
       production:

--- a/docs/tutorials/sample-configMaps/05-namespace-label-selectors.yaml
+++ b/docs/tutorials/sample-configMaps/05-namespace-label-selectors.yaml
@@ -12,8 +12,8 @@ metadata:
 data:
   ns-config: |
     ttlSecondsAfterFinished: 600
-    successfulHistoryLimit: 3
-    failedHistoryLimit: 3
+    successfulHistoryLimit: 30
+    failedHistoryLimit: 30
     
     pipelineRuns:
       - selector:

--- a/docs/tutorials/sample-configMaps/06-namespace-annotation-selectors.yaml
+++ b/docs/tutorials/sample-configMaps/06-namespace-annotation-selectors.yaml
@@ -11,22 +11,22 @@ metadata:
     pruner.tekton.dev/config-type: namespace
 data:
   ns-config: |
-    ttlSecondsAfterFinished: 1800
-    successfulHistoryLimit: 5
-    failedHistoryLimit: 5
-    
+    ttlSecondsAfterFinished: 3600
+    successfulHistoryLimit: 100
+    failedHistoryLimit: 100
+
     pipelineRuns:
       - selector:
         - matchAnnotations:
             release-pipeline: "true"
-        ttlSecondsAfterFinished: 2592000
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 50
         failedHistoryLimit: 20
       
       - selector:
         - matchAnnotations:
             build-schedule: "nightly"
-        ttlSecondsAfterFinished: 86400
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 7
         failedHistoryLimit: 7
       
@@ -47,12 +47,12 @@ data:
       - selector:
         - matchAnnotations:
             scan-type: "security"
-        ttlSecondsAfterFinished: 2592000
-        successfulHistoryLimit: 100
-        failedHistoryLimit: 100
+        ttlSecondsAfterFinished: 3600
+        successfulHistoryLimit: 80
+        failedHistoryLimit: 80
       
       - selector:
         - matchAnnotations:
             scan-type: "quality"
-        ttlSecondsAfterFinished: 604800
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 20

--- a/docs/tutorials/sample-configMaps/07-namespace-mixed-selectors.yaml
+++ b/docs/tutorials/sample-configMaps/07-namespace-mixed-selectors.yaml
@@ -12,9 +12,9 @@ metadata:
     pruner.tekton.dev/config-type: namespace
 data:
   ns-config: |
-    ttlSecondsAfterFinished: 86400
-    successfulHistoryLimit: 10
-    failedHistoryLimit: 10
+    ttlSecondsAfterFinished: 2592000
+    successfulHistoryLimit: 100
+    failedHistoryLimit: 100
     
     pipelineRuns:
       - selector:
@@ -24,7 +24,7 @@ data:
           matchAnnotations:
             compliance-required: "true"
             audit-log: "enabled"
-        ttlSecondsAfterFinished: 2592000
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 50
         failedHistoryLimit: 50
       
@@ -32,7 +32,7 @@ data:
         - matchLabels:
             app: payment-service
             environment: production
-        ttlSecondsAfterFinished: 604800
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 20
         failedHistoryLimit: 10
       
@@ -41,7 +41,7 @@ data:
             deployment-strategy: canary
           matchAnnotations:
             monitoring: "enabled"
-        ttlSecondsAfterFinished: 259200
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 15
     
     taskRuns:
@@ -51,13 +51,13 @@ data:
             component-tier: critical
           matchAnnotations:
             compliance-check: "required"
-        ttlSecondsAfterFinished: 2592000
-        successfulHistoryLimit: 100
+        ttlSecondsAfterFinished: 3600
+        successfulHistoryLimit: 70
       
       - selector:
         - matchLabels:
             task-category: performance
           matchAnnotations:
             environment: "production"
-        ttlSecondsAfterFinished: 1209600
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 30

--- a/docs/tutorials/sample-configMaps/08-namespace-name-based.yaml
+++ b/docs/tutorials/sample-configMaps/08-namespace-name-based.yaml
@@ -12,18 +12,18 @@ metadata:
     pruner.tekton.dev/config-type: namespace
 data:
   ns-config: |
-    ttlSecondsAfterFinished: 1800
-    successfulHistoryLimit: 5
-    failedHistoryLimit: 5
+    ttlSecondsAfterFinished: 2592000
+    successfulHistoryLimit: 100
+    failedHistoryLimit: 100
     
     pipelineRuns:
       - name: production-deployment
-        ttlSecondsAfterFinished: 2592000
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 50
         failedHistoryLimit: 30
       
       - name: nightly-build
-        ttlSecondsAfterFinished: 86400
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 7
         failedHistoryLimit: 7
       
@@ -39,12 +39,12 @@ data:
     
     taskRuns:
       - name: vulnerability-scan
-        ttlSecondsAfterFinished: 2592000
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 100
         failedHistoryLimit: 100
       
       - name: sonar-scan
-        ttlSecondsAfterFinished: 604800
+        ttlSecondsAfterFinished: 3600
         successfulHistoryLimit: 20
       
       - name: unit-tests

--- a/docs/tutorials/sample-configMaps/09-namespace-complete.yaml
+++ b/docs/tutorials/sample-configMaps/09-namespace-complete.yaml
@@ -13,8 +13,8 @@ metadata:
 data:
   ns-config: |
     ttlSecondsAfterFinished: 604800
-    successfulHistoryLimit: 20
-    failedHistoryLimit: 10
+    successfulHistoryLimit: 100
+    failedHistoryLimit: 100
     
     pipelineRuns:
       - name: production-release-pipeline
@@ -30,35 +30,35 @@ data:
             compliance: "pci-dss"
             audit-required: "true"
         ttlSecondsAfterFinished: 2592000
-        successfulHistoryLimit: 100
-        failedHistoryLimit: 100
+        successfulHistoryLimit: 30
+        failedHistoryLimit: 30
       
       - selector:
         - matchAnnotations:
             tekton.dev/release: "true"
         ttlSecondsAfterFinished: 1209600
-        successfulHistoryLimit: 30
-        failedHistoryLimit: 15
-      
-      - selector:
-        - matchLabels:
-            deployment-strategy: canary
-        ttlSecondsAfterFinished: 259200
         successfulHistoryLimit: 15
         failedHistoryLimit: 10
       
       - selector:
         - matchLabels:
+            deployment-strategy: canary
+        ttlSecondsAfterFinished: 259200
+        successfulHistoryLimit: 10
+        failedHistoryLimit: 5
+      
+      - selector:
+        - matchLabels:
             deployment-strategy: blue-green
         ttlSecondsAfterFinished: 432000
-        successfulHistoryLimit: 20
+        successfulHistoryLimit: 10
       
       - selector:
         - matchAnnotations:
             deployment-type: "hotfix"
         ttlSecondsAfterFinished: 2592000
-        successfulHistoryLimit: 50
-        failedHistoryLimit: 50
+        successfulHistoryLimit: 20
+        failedHistoryLimit: 20
       
       - selector:
         - matchLabels:
@@ -66,7 +66,7 @@ data:
           matchAnnotations:
             approval-required: "true"
         ttlSecondsAfterFinished: 1209600
-        successfulHistoryLimit: 30
+        successfulHistoryLimit: 15
     
     taskRuns:
       - name: security-vulnerability-scan
@@ -81,28 +81,28 @@ data:
           matchAnnotations:
             compliance-framework: "pci-dss"
         ttlSecondsAfterFinished: 2592000
-        successfulHistoryLimit: 100
-        failedHistoryLimit: 100
+        successfulHistoryLimit: 30
+        failedHistoryLimit: 30
       
       - selector:
         - matchAnnotations:
             test-type: "penetration"
             security-level: "critical"
         ttlSecondsAfterFinished: 2592000
-        successfulHistoryLimit: 50
+        successfulHistoryLimit: 20
       
       - selector:
         - matchLabels:
             task-category: performance
         ttlSecondsAfterFinished: 604800
-        successfulHistoryLimit: 20
+        successfulHistoryLimit: 10
         failedHistoryLimit: 10
       
       - selector:
         - matchLabels:
             test-type: load-test
         ttlSecondsAfterFinished: 432000
-        successfulHistoryLimit: 15
+        successfulHistoryLimit: 10
       
       - name: db-migration
         ttlSecondsAfterFinished: 2592000
@@ -113,7 +113,7 @@ data:
         - matchAnnotations:
             test-category: "smoke-test"
         ttlSecondsAfterFinished: 86400
-        successfulHistoryLimit: 10
+        successfulHistoryLimit: 5
       
       - selector:
         - matchLabels:
@@ -122,7 +122,7 @@ data:
           matchAnnotations:
             monitoring: "enabled"
         ttlSecondsAfterFinished: 604800
-        successfulHistoryLimit: 30
+        successfulHistoryLimit: 10
       
       - selector:
         - matchLabels:
@@ -135,7 +135,7 @@ data:
         - matchAnnotations:
             quality-gate: "production"
         ttlSecondsAfterFinished: 1209600
-        successfulHistoryLimit: 30
+        successfulHistoryLimit: 5
 
 # NOTES:
 # ------

--- a/pkg/config/config_validation_hierarchical_test.go
+++ b/pkg/config/config_validation_hierarchical_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestValidateConfigMapWithGlobal_HierarchicalFallback tests the hierarchical fallback logic:
+// 1. If global granular limit (successfulHistoryLimit/failedHistoryLimit) is set, use it
+// 2. If only global historyLimit is set, use it for all history-based limits
+// 3. If neither is set, use system maximum
+func TestValidateConfigMapWithGlobal_HierarchicalFallback(t *testing.T) {
+	tests := []struct {
+		name            string
+		globalConfig    string
+		namespaceConfig string
+		wantErr         bool
+		wantErrMsg      string
+	}{
+		{
+			name:            "namespace successfulHistoryLimit uses global historyLimit when no granular limit",
+			globalConfig:    `historyLimit: 50`,
+			namespaceConfig: `successfulHistoryLimit: 50`,
+			wantErr:         false,
+		},
+		{
+			name:            "namespace successfulHistoryLimit exceeds global historyLimit when no granular limit",
+			globalConfig:    `historyLimit: 50`,
+			namespaceConfig: `successfulHistoryLimit: 51`,
+			wantErr:         true,
+			wantErrMsg:      "cannot exceed global historyLimit (50)",
+		},
+		{
+			name:            "namespace failedHistoryLimit uses global historyLimit when no granular limit",
+			globalConfig:    `historyLimit: 50`,
+			namespaceConfig: `failedHistoryLimit: 50`,
+			wantErr:         false,
+		},
+		{
+			name:            "namespace failedHistoryLimit exceeds global historyLimit when no granular limit",
+			globalConfig:    `historyLimit: 50`,
+			namespaceConfig: `failedHistoryLimit: 51`,
+			wantErr:         true,
+			wantErrMsg:      "cannot exceed global historyLimit (50)",
+		},
+		{
+			name: "granular limit takes precedence over historyLimit",
+			globalConfig: `historyLimit: 50
+successfulHistoryLimit: 30`,
+			namespaceConfig: `successfulHistoryLimit: 30`,
+			wantErr:         false,
+		},
+		{
+			name: "namespace exceeds granular limit even though within historyLimit",
+			globalConfig: `historyLimit: 50
+successfulHistoryLimit: 30`,
+			namespaceConfig: `successfulHistoryLimit: 40`,
+			wantErr:         true,
+			wantErrMsg:      "cannot exceed global limit (30)",
+		},
+		{
+			name: "both granular limits set, namespace within both",
+			globalConfig: `successfulHistoryLimit: 40
+failedHistoryLimit: 20`,
+			namespaceConfig: `successfulHistoryLimit: 40
+failedHistoryLimit: 20`,
+			wantErr: false,
+		},
+		{
+			name:         "only one granular limit set, other uses system maximum",
+			globalConfig: `successfulHistoryLimit: 40`,
+			namespaceConfig: `successfulHistoryLimit: 40
+failedHistoryLimit: 100`,
+			wantErr: false,
+		},
+		{
+			name:         "only one granular limit set, other exceeds system maximum",
+			globalConfig: `successfulHistoryLimit: 40`,
+			namespaceConfig: `successfulHistoryLimit: 40
+failedHistoryLimit: 101`,
+			wantErr:    true,
+			wantErrMsg: "cannot exceed system maximum (100)",
+		},
+		{
+			name:            "no global limits at all, namespace uses system maximum",
+			globalConfig:    `ttlSecondsAfterFinished: 3600`,
+			namespaceConfig: `successfulHistoryLimit: 100`,
+			wantErr:         false,
+		},
+		{
+			name:            "no global limits, namespace exceeds system maximum",
+			globalConfig:    `ttlSecondsAfterFinished: 3600`,
+			namespaceConfig: `successfulHistoryLimit: 101`,
+			wantErr:         true,
+			wantErrMsg:      "cannot exceed system maximum (100)",
+		},
+		{
+			name:         "global historyLimit 200, namespace successful 200 allowed",
+			globalConfig: `historyLimit: 200`,
+			namespaceConfig: `successfulHistoryLimit: 200
+failedHistoryLimit: 200`,
+			wantErr: false,
+		},
+		{
+			name:         "global historyLimit 200, namespace exceeds",
+			globalConfig: `historyLimit: 200`,
+			namespaceConfig: `successfulHistoryLimit: 201
+failedHistoryLimit: 150`,
+			wantErr:    true,
+			wantErrMsg: "cannot exceed global historyLimit (200)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			globalCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      PrunerConfigMapName,
+					Namespace: "tekton-pipelines",
+				},
+				Data: map[string]string{
+					PrunerGlobalConfigKey: tt.globalConfig,
+				},
+			}
+
+			namespaceCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      PrunerNamespaceConfigMapName,
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					PrunerNamespaceConfigKey: tt.namespaceConfig,
+				},
+			}
+
+			err := ValidateConfigMapWithGlobal(namespaceCM, globalCM)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', got nil", tt.wantErrMsg)
+				} else if !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("Expected error containing '%s', got '%s'", tt.wantErrMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/config/config_validation_test.go
+++ b/pkg/config/config_validation_test.go
@@ -203,7 +203,7 @@ func TestValidateConfigMap_InvalidNamespaceConfig(t *testing.T) {
 		{
 			name:       "invalid YAML",
 			config:     `bad yaml: [[[`,
-			wantErrMsg: "failed to parse namespace-config",
+			wantErrMsg: "failed to parse ns-config",
 		},
 	}
 
@@ -534,11 +534,10 @@ func TestValidateConfigMap_SystemMaximumEnforcement(t *testing.T) {
 		wantErrMsg string
 	}{
 		{
-			name:       "global config exceeds system maximum TTL",
+			name:       "global config can exceed system maximum TTL",
 			configType: "global",
 			config:     `ttlSecondsAfterFinished: 2592001`,
-			wantErr:    true,
-			wantErrMsg: "cannot exceed system maximum (2592000 seconds / 30 days)",
+			wantErr:    false,
 		},
 		{
 			name:       "global config at system maximum TTL",
@@ -547,11 +546,10 @@ func TestValidateConfigMap_SystemMaximumEnforcement(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:       "global config exceeds system maximum successfulHistoryLimit",
+			name:       "global config can exceed system maximum successfulHistoryLimit",
 			configType: "global",
 			config:     `successfulHistoryLimit: 101`,
-			wantErr:    true,
-			wantErrMsg: "cannot exceed system maximum (100)",
+			wantErr:    false,
 		},
 		{
 			name:       "global config at system maximum successfulHistoryLimit",
@@ -560,11 +558,10 @@ func TestValidateConfigMap_SystemMaximumEnforcement(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:       "global config exceeds system maximum failedHistoryLimit",
+			name:       "global config can exceed system maximum failedHistoryLimit",
 			configType: "global",
 			config:     `failedHistoryLimit: 150`,
-			wantErr:    true,
-			wantErrMsg: "cannot exceed system maximum (100)",
+			wantErr:    false,
 		},
 		{
 			name:       "global config at system maximum failedHistoryLimit",
@@ -573,11 +570,10 @@ func TestValidateConfigMap_SystemMaximumEnforcement(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:       "global config exceeds system maximum historyLimit",
+			name:       "global config can exceed system maximum historyLimit",
 			configType: "global",
 			config:     `historyLimit: 200`,
-			wantErr:    true,
-			wantErrMsg: "cannot exceed system maximum (100)",
+			wantErr:    false,
 		},
 		{
 			name:       "global config at system maximum historyLimit",
@@ -612,13 +608,12 @@ func TestValidateConfigMap_SystemMaximumEnforcement(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:       "global config with multiple fields exceeding system maximum",
+			name:       "global config can have multiple fields exceeding system maximum",
 			configType: "global",
 			config: `ttlSecondsAfterFinished: 3000000
 successfulHistoryLimit: 150
 failedHistoryLimit: 200`,
-			wantErr:    true,
-			wantErrMsg: "cannot exceed system maximum",
+			wantErr: false,
 		},
 	}
 

--- a/pkg/webhook/configmapvalidation_test.go
+++ b/pkg/webhook/configmapvalidation_test.go
@@ -552,11 +552,10 @@ func TestValidateConfigMap_Admit_SystemMaximumEnforcement(t *testing.T) {
 		wantMessage string
 	}{
 		{
-			name:        "global config exceeds system maximum TTL",
+			name:        "global config can exceed system maximum TTL",
 			configType:  "global",
 			configData:  `ttlSecondsAfterFinished: 2592001`,
-			wantAllowed: false,
-			wantMessage: "cannot exceed system maximum (2592000 seconds / 30 days)",
+			wantAllowed: true,
 		},
 		{
 			name:        "global config at system maximum TTL",
@@ -565,11 +564,10 @@ func TestValidateConfigMap_Admit_SystemMaximumEnforcement(t *testing.T) {
 			wantAllowed: true,
 		},
 		{
-			name:        "global config exceeds system maximum successfulHistoryLimit",
+			name:        "global config can exceed system maximum successfulHistoryLimit",
 			configType:  "global",
 			configData:  `successfulHistoryLimit: 101`,
-			wantAllowed: false,
-			wantMessage: "cannot exceed system maximum (100)",
+			wantAllowed: true,
 		},
 		{
 			name:        "global config at system maximum successfulHistoryLimit",

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -883,13 +883,13 @@ func testWebhookSystemMaximumEnforcement(ctx context.Context, t *testing.T, kube
 		shouldFail  bool
 		description string
 	}{
-		// Global config tests
+		// Global config tests - global configs can exceed system maximums
 		{
-			name:        "global config exceeds system maximum TTL",
+			name:        "global config can exceed system maximum TTL",
 			configType:  "global",
 			config:      `ttlSecondsAfterFinished: 2592001`,
-			shouldFail:  true,
-			description: "TTL of 2592001 seconds exceeds system maximum of 2592000 seconds (30 days)",
+			shouldFail:  false,
+			description: "TTL of 2592001 seconds exceeds system maximum but allowed for global config",
 		},
 		{
 			name:        "global config at system maximum TTL",
@@ -899,11 +899,11 @@ func testWebhookSystemMaximumEnforcement(ctx context.Context, t *testing.T, kube
 			description: "TTL of 2592000 seconds is at system maximum",
 		},
 		{
-			name:        "global config exceeds system maximum successfulHistoryLimit",
+			name:        "global config can exceed system maximum successfulHistoryLimit",
 			configType:  "global",
 			config:      `successfulHistoryLimit: 101`,
-			shouldFail:  true,
-			description: "successfulHistoryLimit of 101 exceeds system maximum of 100",
+			shouldFail:  false,
+			description: "successfulHistoryLimit of 101 exceeds system maximum but allowed for global config",
 		},
 		{
 			name:        "global config at system maximum successfulHistoryLimit",
@@ -913,18 +913,26 @@ func testWebhookSystemMaximumEnforcement(ctx context.Context, t *testing.T, kube
 			description: "successfulHistoryLimit of 100 is at system maximum",
 		},
 		{
-			name:        "global config exceeds system maximum failedHistoryLimit",
+			name:        "global config can exceed system maximum failedHistoryLimit",
 			configType:  "global",
 			config:      `failedHistoryLimit: 150`,
-			shouldFail:  true,
-			description: "failedHistoryLimit of 150 exceeds system maximum of 100",
+			shouldFail:  false,
+			description: "failedHistoryLimit of 150 exceeds system maximum but allowed for global config",
 		},
 		{
-			name:        "global config exceeds system maximum historyLimit",
+			name:        "global config can exceed system maximum historyLimit",
 			configType:  "global",
 			config:      `historyLimit: 200`,
-			shouldFail:  true,
-			description: "historyLimit of 200 exceeds system maximum of 100",
+			shouldFail:  false,
+			description: "historyLimit of 200 exceeds system maximum but allowed for global config",
+		},
+		// Clear global config before namespace-only tests
+		{
+			name:        "reset global config to empty for namespace tests",
+			configType:  "global",
+			config:      `{}`,
+			shouldFail:  false,
+			description: "reset global config to test namespace configs against system maximum only",
 		},
 		// Namespace config tests (without global limits)
 		{


### PR DESCRIPTION
# Changes

This pull request enhances the validation logic in `pkg/config/config.go` for pruner configuration limits and ConfigMap samples were updated to reflect correct values.

**Validation Logic Improvements (`pkg/config/config.go`):**
* Changed error messages to use `ns-config` instead of `namespace-config` for consistency and clarity.
* Added logic to validate selector-based limits, enforcing that the sum of selector limits does not exceed namespace/global limits, and supporting a four-tier hierarchy (global, namespace, selector, system maximum).
* Introduced `isNamespaceConfig` detection to ensure namespace configs are validated against global or system maximums as appropriate.
* Improved validation for `successfulHistoryLimit` and `failedHistoryLimit` to prioritize global granular limits, then fallback to global aggregate limits, and finally system maximums.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind bug