### PR TITLE
fix: process selector configs

### DIFF
--- a/pkg/config/config_selector_test.go
+++ b/pkg/config/config_selector_test.go
@@ -162,10 +162,17 @@ func TestSelectorMatching_Precedence(t *testing.T) {
 			wantID:       "identifiedBy_resource_selector",
 		},
 		{
-			name:         "no match when name doesn't exist",
+			name:         "selector match when name doesn't exist",
 			resourceName: "non-existent",
 			selector:     SelectorSpec{MatchLabels: map[string]string{"app": "myapp"}},
-			wantTTL:      0,
+			wantTTL:      3600, // Falls through to selector matching after name mismatch
+			wantID:       "identifiedBy_resource_selector",
+		},
+		{
+			name:         "no match when both name and selector don't match",
+			resourceName: "non-existent",
+			selector:     SelectorSpec{MatchLabels: map[string]string{"app": "different"}},
+			wantTTL:      0, // Neither name nor selector match
 			wantID:       "",
 		},
 	}


### PR DESCRIPTION
# Changes

This pull request refines how resource selection and cleanup are handled in the pruner configuration logic.

### Selector Matching Logic Improvements

* Changed the fallback behavior when a resource name does not match: the code now continues to selector-based matching instead of immediately returning, allowing resources to be identified by selectors if the name is not found.
* Refactored selector matching to ensure that all required labels and annotations specified in the ConfigMap must exist in the resource for a match, using AND logic for both labels and annotations. )
* Removed unnecessary nested block in `GetEnforcedConfigLevelFromNamespaceSpec` for clarity.

### Test Coverage Enhancements

* Updated and expanded unit tests to verify that selector matching occurs when a resource name does not exist, and to check the case where neither name nor selector match.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind bug