### PR TITLE
fix: add missing unit test cases

### DIFF
--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestLoadGlobalConfig verifies global configuration loading from ConfigMap.
+func TestLoadGlobalConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		configData  string
+		expectError bool
+		validateTTL *int32
+	}{
+		{
+			name: "Valid config with TTL",
+			configData: `
+ttlSecondsAfterFinished: 3600
+successfulHistoryLimit: 5
+failedHistoryLimit: 3`,
+			expectError: false,
+			validateTTL: intPtr(int32(3600)),
+		},
+		{
+			name:        "Empty config",
+			configData:  "",
+			expectError: false,
+			validateTTL: nil,
+		},
+		{
+			name: "Config with namespaces",
+			configData: `
+ttlSecondsAfterFinished: 3600
+namespaces:
+  test-ns:
+    ttlSecondsAfterFinished: 7200`,
+			expectError: false,
+			validateTTL: intPtr(int32(3600)),
+		},
+		{
+			name:        "Invalid YAML",
+			configData:  "ttlSecondsAfterFinished: invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ps := &prunerConfigStore{namespaceConfig: make(map[string]NamespaceSpec)}
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+				Data:       map[string]string{PrunerGlobalConfigKey: tt.configData},
+			}
+
+			err := ps.LoadGlobalConfig(context.Background(), cm)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.validateTTL, ps.globalConfig.TTLSecondsAfterFinished)
+			}
+		})
+	}
+}
+
+// TestLoadNamespaceConfig verifies namespace-specific configuration loading.
+func TestLoadNamespaceConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		configData  string
+		expectError bool
+	}{
+		{
+			name:      "Valid namespace config",
+			namespace: "test-ns",
+			configData: `
+ttlSecondsAfterFinished: 1800
+successfulHistoryLimit: 3`,
+			expectError: false,
+		},
+		{
+			name:      "Config with PipelineRun selectors",
+			namespace: "test-ns",
+			configData: `
+pipelineRuns:
+  - name: my-pipeline
+    ttlSecondsAfterFinished: 7200`,
+			expectError: false,
+		},
+		{
+			name:      "Config with TaskRun selectors",
+			namespace: "test-ns",
+			configData: `
+taskRuns:
+  - selector:
+      - matchLabels:
+          app: myapp`,
+			expectError: false,
+		},
+		{
+			name:        "Invalid YAML",
+			namespace:   "test-ns",
+			configData:  "invalid: yaml: ::::",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ps := &prunerConfigStore{namespaceConfig: make(map[string]NamespaceSpec)}
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: tt.namespace},
+				Data:       map[string]string{PrunerNamespaceConfigKey: tt.configData},
+			}
+
+			err := ps.LoadNamespaceConfig(context.Background(), tt.namespace, cm)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				_, exists := ps.namespaceConfig[tt.namespace]
+				assert.True(t, exists)
+			}
+		})
+	}
+}
+
+// TestDeleteNamespaceConfig verifies namespace configuration deletion.
+func TestDeleteNamespaceConfig(t *testing.T) {
+	ps := &prunerConfigStore{namespaceConfig: make(map[string]NamespaceSpec)}
+	ttl := int32(3600)
+	ps.namespaceConfig["ns1"] = NamespaceSpec{PrunerConfig: PrunerConfig{TTLSecondsAfterFinished: &ttl}}
+	ps.namespaceConfig["ns2"] = NamespaceSpec{PrunerConfig: PrunerConfig{TTLSecondsAfterFinished: &ttl}}
+
+	ps.DeleteNamespaceConfig(context.Background(), "ns1")
+
+	assert.Len(t, ps.namespaceConfig, 1)
+	_, exists := ps.namespaceConfig["ns1"]
+	assert.False(t, exists)
+	_, exists = ps.namespaceConfig["ns2"]
+	assert.True(t, exists)
+}
+
+// TestGetPipelineConfig verifies pipeline config retrieval with fallback hierarchy.
+func TestGetPipelineConfig(t *testing.T) {
+	ps := &prunerConfigStore{namespaceConfig: make(map[string]NamespaceSpec)}
+	globalTTL := int32(3600)
+	globalLimit := int32(5)
+	ps.globalConfig = GlobalConfig{
+		PrunerConfig: PrunerConfig{
+			TTLSecondsAfterFinished: &globalTTL,
+			SuccessfulHistoryLimit:  &globalLimit,
+		},
+	}
+
+	ttl, source := ps.GetPipelineTTLSecondsAfterFinished("test-ns", "", SelectorSpec{})
+	assert.NotNil(t, ttl)
+	assert.NotEmpty(t, source)
+	assert.Equal(t, globalTTL, *ttl)
+
+	limit, source := ps.GetPipelineSuccessHistoryLimitCount("test-ns", "", SelectorSpec{})
+	assert.NotNil(t, limit)
+	assert.NotEmpty(t, source)
+	assert.Equal(t, globalLimit, *limit)
+}
+
+// TestGetTaskConfig verifies task config retrieval with fallback hierarchy.
+func TestGetTaskConfig(t *testing.T) {
+	ps := &prunerConfigStore{namespaceConfig: make(map[string]NamespaceSpec)}
+	globalTTL := int32(1800)
+	globalLimit := int32(10)
+	ps.globalConfig = GlobalConfig{
+		PrunerConfig: PrunerConfig{
+			TTLSecondsAfterFinished: &globalTTL,
+			SuccessfulHistoryLimit:  &globalLimit,
+		},
+	}
+
+	ttl, source := ps.GetTaskTTLSecondsAfterFinished("test-ns", "", SelectorSpec{})
+	assert.NotNil(t, ttl)
+	assert.NotEmpty(t, source)
+	assert.Equal(t, globalTTL, *ttl)
+
+	limit, source := ps.GetTaskSuccessHistoryLimitCount("test-ns", "", SelectorSpec{})
+	assert.NotNil(t, limit)
+	assert.NotEmpty(t, source)
+	assert.Equal(t, globalLimit, *limit)
+}
+
+// TestConcurrentAccess verifies thread-safe config access via mutex.
+func TestConcurrentAccess(t *testing.T) {
+	ps := &prunerConfigStore{namespaceConfig: make(map[string]NamespaceSpec)}
+	ttl := int32(3600)
+	ps.globalConfig = GlobalConfig{PrunerConfig: PrunerConfig{TTLSecondsAfterFinished: &ttl}}
+
+	done := make(chan bool, 2)
+
+	// Concurrent writer
+	go func() {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+			Data:       map[string]string{PrunerGlobalConfigKey: "ttlSecondsAfterFinished: 7200"},
+		}
+		for i := 0; i < 50; i++ {
+			_ = ps.LoadGlobalConfig(context.Background(), cm)
+		}
+		done <- true
+	}()
+
+	// Concurrent reader
+	go func() {
+		for i := 0; i < 50; i++ {
+			_, _ = ps.GetPipelineTTLSecondsAfterFinished("test-ns", "", SelectorSpec{})
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+}
+
+func intPtr(i int32) *int32 { return &i }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestGetRecorder verifies singleton pattern for recorder.
+func TestGetRecorder(t *testing.T) {
+	recorder1 := GetRecorder()
+	recorder2 := GetRecorder()
+
+	assert.NotNil(t, recorder1)
+	assert.Equal(t, recorder1, recorder2)
+}
+
+// TestNewRecorder ensures recorder initialization includes all required metrics.
+func TestNewRecorder(t *testing.T) {
+	r := newRecorder()
+
+	assert.NotNil(t, r.resourcesProcessed)
+	assert.NotNil(t, r.resourcesDeleted)
+	assert.NotNil(t, r.resourcesErrors)
+	assert.NotNil(t, r.reconciliationDuration)
+	assert.NotNil(t, r.seenResources)
+	assert.Empty(t, r.seenResources)
+}
+
+// TestTimer verifies timer creation and recording operations.
+func TestTimer(t *testing.T) {
+	r := newRecorder()
+	ctx := context.Background()
+
+	timer := r.NewTimer()
+	assert.NotNil(t, timer)
+	time.Sleep(10 * time.Millisecond)
+
+	assert.NotPanics(t, func() {
+		timer.RecordReconciliationDuration(ctx)
+	})
+	assert.NotPanics(t, func() {
+		timer.RecordTTLProcessingDuration(ctx)
+	})
+	assert.NotPanics(t, func() {
+		timer.RecordHistoryProcessingDuration(ctx)
+	})
+}
+
+// TestRecordReconciliationEvent verifies event recording with various statuses.
+func TestRecordReconciliationEvent(t *testing.T) {
+	r := newRecorder()
+	ctx := context.Background()
+
+	tests := []struct {
+		resourceType string
+		namespace    string
+		status       string
+	}{
+		{ResourceTypePipelineRun, "default", StatusSuccess},
+		{ResourceTypeTaskRun, "test-ns", StatusFailed},
+	}
+
+	for _, tt := range tests {
+		assert.NotPanics(t, func() {
+			r.RecordReconciliationEvent(ctx, tt.resourceType, tt.namespace, tt.status)
+		})
+	}
+}
+
+// TestRecordResourceProcessed verifies duplicate resource detection via UID cache.
+func TestRecordResourceProcessed(t *testing.T) {
+	r := newRecorder()
+	ctx := context.Background()
+
+	uid1 := types.UID("test-uid-1")
+	uid2 := types.UID("test-uid-2")
+
+	r.RecordResourceProcessed(ctx, uid1, ResourceTypePipelineRun, "default", StatusSuccess)
+	assert.True(t, r.seenResources[uid1])
+
+	r.RecordResourceProcessed(ctx, uid1, ResourceTypePipelineRun, "default", StatusSuccess)
+	assert.Len(t, r.seenResources, 1)
+
+	r.RecordResourceProcessed(ctx, uid2, ResourceTypeTaskRun, "test-ns", StatusFailed)
+	assert.Len(t, r.seenResources, 2)
+}
+
+// TestRecordResourceDeleted verifies deletion tracking with resource age.
+func TestRecordResourceDeleted(t *testing.T) {
+	r := newRecorder()
+	ctx := context.Background()
+
+	assert.NotPanics(t, func() {
+		r.RecordResourceDeleted(ctx, ResourceTypePipelineRun, "default", OperationTTL, 1*time.Hour)
+	})
+}
+
+// TestRecordResourceError verifies error recording with classification.
+func TestRecordResourceError(t *testing.T) {
+	r := newRecorder()
+	ctx := context.Background()
+
+	tests := []struct {
+		errorType string
+		reason    string
+	}{
+		{ErrorTypeAPI, "Failed to delete"},
+		{ErrorTypeTimeout, "Context deadline exceeded"},
+	}
+
+	for _, tt := range tests {
+		assert.NotPanics(t, func() {
+			r.RecordResourceError(ctx, ResourceTypePipelineRun, "default", tt.errorType, tt.reason)
+		})
+	}
+}
+
+// TestUpdateActiveResourcesCount verifies gauge updates for resource tracking.
+func TestUpdateActiveResourcesCount(t *testing.T) {
+	r := newRecorder()
+	ctx := context.Background()
+
+	assert.NotPanics(t, func() {
+		r.UpdateActiveResourcesCount(ctx, ResourceTypePipelineRun, "default", 5)
+	})
+	assert.NotPanics(t, func() {
+		r.UpdateActiveResourcesCount(ctx, ResourceTypeTaskRun, "test-ns", -3)
+	})
+}
+
+// TestResourceAttributes verifies attribute construction for metrics.
+func TestResourceAttributes(t *testing.T) {
+	attrs := ResourceAttributes(ResourceTypePipelineRun, "default")
+
+	assert.Len(t, attrs, 2)
+	keys := make(map[string]bool)
+	for _, attr := range attrs {
+		keys[string(attr.Key)] = true
+	}
+	assert.True(t, keys[LabelResourceType])
+	assert.True(t, keys[LabelNamespace])
+}
+
+// TestErrorAttributes verifies error attribute construction.
+func TestErrorAttributes(t *testing.T) {
+	attrs := ErrorAttributes(ResourceTypePipelineRun, "default", ErrorTypeAPI, "Failed")
+
+	assert.Len(t, attrs, 4)
+	keys := make(map[string]bool)
+	for _, attr := range attrs {
+		keys[string(attr.Key)] = true
+	}
+	assert.True(t, keys[LabelResourceType])
+	assert.True(t, keys[LabelNamespace])
+	assert.True(t, keys[LabelErrorType])
+	assert.True(t, keys[LabelReason])
+}
+
+// TestClassifyError verifies error type classification for Kubernetes errors.
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{"Nil error", nil, ""},
+		{"Not found", errors.NewNotFound(schema.GroupResource{}, "test"), ErrorTypeNotFound},
+		{"Forbidden", errors.NewForbidden(schema.GroupResource{}, "test", nil), ErrorTypePermission},
+		{"Unauthorized", errors.NewUnauthorized("test"), ErrorTypePermission},
+		{"Bad request", errors.NewBadRequest("test"), ErrorTypeValidation},
+		{"Invalid", errors.NewInvalid(schema.GroupKind{}, "test", nil), ErrorTypeValidation},
+		{"Timeout", errors.NewTimeoutError("test", 30), ErrorTypeTimeout},
+		{"Internal", errors.NewInternalError(errors.NewBadRequest("test")), ErrorTypeAPI},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ClassifyError(tt.err))
+		})
+	}
+}
+
+// TestIsAPIError verifies API error detection.
+func TestIsAPIError(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected bool
+	}{
+		{errors.NewInternalError(errors.NewBadRequest("test")), true},
+		{errors.NewServiceUnavailable("test"), true},
+		{errors.NewNotFound(schema.GroupResource{}, "test"), false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, isAPIError(tt.err))
+	}
+}
+
+// TestIsTimeoutError verifies timeout error detection.
+func TestIsTimeoutError(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected bool
+	}{
+		{errors.NewTimeoutError("test", 30), true},
+		{errors.NewServerTimeout(schema.GroupResource{}, "test", 1), true},
+		{errors.NewNotFound(schema.GroupResource{}, "test"), false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, isTimeoutError(tt.err))
+	}
+}
+
+// TestIsPermissionError verifies permission error detection.
+func TestIsPermissionError(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected bool
+	}{
+		{errors.NewForbidden(schema.GroupResource{}, "test", nil), true},
+		{errors.NewUnauthorized("test"), true},
+		{errors.NewNotFound(schema.GroupResource{}, "test"), false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, isPermissionError(tt.err))
+	}
+}

--- a/pkg/reconciler/namespaceprunerconfig/reconciler_additional_test.go
+++ b/pkg/reconciler/namespaceprunerconfig/reconciler_additional_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespaceprunerconfig
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/pruner/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+// TestReconcileValidConfigs verifies reconciliation with various valid configurations.
+func TestReconcileValidConfigs(t *testing.T) {
+	tests := []struct {
+		name       string
+		configData string
+	}{
+		{
+			name: "TTL config",
+			configData: `
+ttlSecondsAfterFinished: 3600
+successfulHistoryLimit: 10`,
+		},
+		{
+			name: "PipelineRun selectors",
+			configData: `
+pipelineRuns:
+  - name: my-pipeline
+    ttlSecondsAfterFinished: 7200`,
+		},
+		{
+			name: "TaskRun selectors",
+			configData: `
+taskRuns:
+  - selector:
+      - matchLabels:
+          app: myapp
+    successfulHistoryLimit: 5`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.WithLogger(context.Background(), logtesting.TestLogger(t))
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      config.PrunerNamespaceConfigMapName,
+					Namespace: "test-ns",
+				},
+				Data: map[string]string{config.PrunerNamespaceConfigKey: tt.configData},
+			}
+
+			reconciler := &Reconciler{kubeclient: fake.NewSimpleClientset(cm)}
+			err := reconciler.Reconcile(ctx, "test-ns/"+config.PrunerNamespaceConfigMapName)
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestReconcileInvalidConfig verifies error handling for invalid YAML.
+func TestReconcileInvalidConfig(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logtesting.TestLogger(t))
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.PrunerNamespaceConfigMapName,
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{config.PrunerNamespaceConfigKey: "invalid: yaml: ::::"},
+	}
+
+	reconciler := &Reconciler{kubeclient: fake.NewSimpleClientset(cm)}
+	err := reconciler.Reconcile(ctx, "test-ns/"+config.PrunerNamespaceConfigMapName)
+
+	assert.Error(t, err)
+}
+
+// TestReconcileConfigMapNotFound verifies handling of deleted ConfigMaps.
+func TestReconcileConfigMapNotFound(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logtesting.TestLogger(t))
+	reconciler := &Reconciler{kubeclient: fake.NewSimpleClientset()}
+
+	err := reconciler.Reconcile(ctx, "test-ns/"+config.PrunerNamespaceConfigMapName)
+
+	assert.NoError(t, err)
+}
+
+// TestReconcileConfigMapUpdate verifies config updates are processed.
+func TestReconcileConfigMapUpdate(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logtesting.TestLogger(t))
+	initialCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.PrunerNamespaceConfigMapName,
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{config.PrunerNamespaceConfigKey: "ttlSecondsAfterFinished: 3600"},
+	}
+
+	kubeClient := fake.NewSimpleClientset(initialCM)
+	reconciler := &Reconciler{kubeclient: kubeClient}
+
+	err := reconciler.Reconcile(ctx, "test-ns/"+config.PrunerNamespaceConfigMapName)
+	assert.NoError(t, err)
+
+	updatedCM := initialCM.DeepCopy()
+	updatedCM.Data[config.PrunerNamespaceConfigKey] = "ttlSecondsAfterFinished: 7200"
+	_, err = kubeClient.CoreV1().ConfigMaps("test-ns").Update(ctx, updatedCM, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	err = reconciler.Reconcile(ctx, "test-ns/"+config.PrunerNamespaceConfigMapName)
+	assert.NoError(t, err)
+}
+
+// TestReconcileMultipleNamespaces verifies independent namespace config handling.
+func TestReconcileMultipleNamespaces(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logtesting.TestLogger(t))
+	cm1 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: config.PrunerNamespaceConfigMapName, Namespace: "ns1"},
+		Data:       map[string]string{config.PrunerNamespaceConfigKey: "ttlSecondsAfterFinished: 1800"},
+	}
+	cm2 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: config.PrunerNamespaceConfigMapName, Namespace: "ns2"},
+		Data:       map[string]string{config.PrunerNamespaceConfigKey: "ttlSecondsAfterFinished: 3600"},
+	}
+
+	reconciler := &Reconciler{kubeclient: fake.NewSimpleClientset(cm1, cm2)}
+
+	assert.NoError(t, reconciler.Reconcile(ctx, "ns1/"+config.PrunerNamespaceConfigMapName))
+	assert.NoError(t, reconciler.Reconcile(ctx, "ns2/"+config.PrunerNamespaceConfigMapName))
+}
+
+// TestReconcileEmptyData verifies graceful handling of empty ConfigMap data.
+func TestReconcileEmptyData(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logtesting.TestLogger(t))
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.PrunerNamespaceConfigMapName,
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{},
+	}
+
+	reconciler := &Reconciler{kubeclient: fake.NewSimpleClientset(cm)}
+	err := reconciler.Reconcile(ctx, "test-ns/"+config.PrunerNamespaceConfigMapName)
+
+	assert.NoError(t, err)
+}
+
+// TestParseKeyVariations verifies key parsing edge cases.
+func TestParseKeyVariations(t *testing.T) {
+	tests := []struct {
+		key         string
+		wantNS      string
+		wantName    string
+		expectError bool
+	}{
+		{key: "test-ns/config-map", wantNS: "test-ns", wantName: "config-map", expectError: false},
+		{key: "invalid-key", expectError: true},
+		{key: "ns/name/extra", wantNS: "ns", wantName: "name/extra", expectError: false}, // SplitN allows this
+		{key: "", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			ns, name, err := parseKey(tt.key)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantNS, ns)
+				assert.Equal(t, tt.wantName, name)
+			}
+		})
+	}
+}
+
+// TestConcurrentReconciliation verifies thread-safe concurrent reconciliation.
+func TestConcurrentReconciliation(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logtesting.TestLogger(t))
+
+	var runtimeObjs []runtime.Object
+	for i := 1; i <= 5; i++ {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.PrunerNamespaceConfigMapName,
+				Namespace: fmt.Sprintf("concurrent-ns-%d", i),
+			},
+			Data: map[string]string{config.PrunerNamespaceConfigKey: "ttlSecondsAfterFinished: 3600"},
+		}
+		runtimeObjs = append(runtimeObjs, cm)
+	}
+
+	reconciler := &Reconciler{kubeclient: fake.NewSimpleClientset(runtimeObjs...)}
+	done := make(chan bool, 5)
+
+	for i := 1; i <= 5; i++ {
+		go func(idx int) {
+			key := fmt.Sprintf("concurrent-ns-%d/%s", idx, config.PrunerNamespaceConfigMapName)
+			err := reconciler.Reconcile(ctx, key)
+			assert.NoError(t, err)
+			done <- true
+		}(i)
+	}
+
+	for i := 0; i < 5; i++ {
+		<-done
+	}
+}

--- a/pkg/reconciler/pipelinerun/reconciler_additional_test.go
+++ b/pkg/reconciler/pipelinerun/reconciler_additional_test.go
@@ -1,0 +1,480 @@
+package pipelinerun
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	fakepipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestNewPrFuncs(t *testing.T) {
+	client := fakepipelineclientset.NewSimpleClientset()
+	prFuncs := NewPrFuncs(client)
+
+	assert.NotNil(t, prFuncs)
+	assert.NotNil(t, prFuncs.client)
+	assert.Equal(t, client, prFuncs.client)
+}
+
+func TestListByLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		prs           []*pipelinev1.PipelineRun
+		namespace     string
+		labels        map[string]string
+		expectedCount int
+	}{
+		{
+			name:      "No PipelineRuns",
+			prs:       []*pipelinev1.PipelineRun{},
+			namespace: "default",
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "Single matching PipelineRun",
+			prs: []*pipelinev1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Multiple matching PipelineRuns",
+			prs: []*pipelinev1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+							"env": "prod",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-2",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+							"env": "prod",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-3",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "other",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			// Create fake client with PipelineRuns
+			var runtimeObjs []runtime.Object
+			for _, pr := range tt.prs {
+				runtimeObjs = append(runtimeObjs, pr)
+			}
+			client := fakepipelineclientset.NewSimpleClientset(runtimeObjs...)
+			prFuncs := NewPrFuncs(client)
+
+			// Call ListByLabels
+			result, err := prFuncs.ListByLabels(ctx, tt.namespace, tt.labels)
+
+			assert.NoError(t, err)
+			assert.Len(t, result, tt.expectedCount)
+		})
+	}
+}
+
+func TestListByAnnotations(t *testing.T) {
+	tests := []struct {
+		name          string
+		prs           []*pipelinev1.PipelineRun
+		namespace     string
+		annotations   map[string]string
+		expectedCount int
+	}{
+		{
+			name:      "No PipelineRuns",
+			prs:       []*pipelinev1.PipelineRun{},
+			namespace: "default",
+			annotations: map[string]string{
+				"owner": "team-a",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "Single matching PipelineRun",
+			prs: []*pipelinev1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"owner": "team-a",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			annotations: map[string]string{
+				"owner": "team-a",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Multiple matching PipelineRuns",
+			prs: []*pipelinev1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"owner":   "team-a",
+							"project": "myproject",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-2",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"owner":   "team-a",
+							"project": "myproject",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			annotations: map[string]string{
+				"owner": "team-a",
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			// Create fake client with PipelineRuns
+			var runtimeObjs []runtime.Object
+			for _, pr := range tt.prs {
+				runtimeObjs = append(runtimeObjs, pr)
+			}
+			client := fakepipelineclientset.NewSimpleClientset(runtimeObjs...)
+			prFuncs := NewPrFuncs(client)
+
+			// Call ListByAnnotations
+			result, err := prFuncs.ListByAnnotations(ctx, tt.namespace, tt.annotations)
+
+			assert.NoError(t, err)
+			assert.Len(t, result, tt.expectedCount)
+		})
+	}
+}
+
+func TestListByNamespaces(t *testing.T) {
+	tests := []struct {
+		name               string
+		prs                []*pipelinev1.PipelineRun
+		namespaces         []string
+		expectedNamespaces int
+	}{
+		{
+			name:               "No namespaces",
+			prs:                []*pipelinev1.PipelineRun{},
+			namespaces:         []string{},
+			expectedNamespaces: 0,
+		},
+		{
+			name: "Single namespace with PipelineRuns",
+			prs: []*pipelinev1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-1",
+						Namespace: "ns1",
+					},
+				},
+			},
+			namespaces:         []string{"ns1"},
+			expectedNamespaces: 1,
+		},
+		{
+			name: "Multiple namespaces",
+			prs: []*pipelinev1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-1",
+						Namespace: "ns1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-2",
+						Namespace: "ns2",
+					},
+				},
+			},
+			namespaces:         []string{"ns1", "ns2"},
+			expectedNamespaces: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			// Create fake client with PipelineRuns
+			var runtimeObjs []runtime.Object
+			for _, pr := range tt.prs {
+				runtimeObjs = append(runtimeObjs, pr)
+			}
+			client := fakepipelineclientset.NewSimpleClientset(runtimeObjs...)
+			prFuncs := NewPrFuncs(client)
+
+			// Call ListByNamespaces
+			result, err := prFuncs.ListByNamespaces(ctx, tt.namespaces)
+
+			assert.NoError(t, err)
+			assert.Len(t, result, tt.expectedNamespaces)
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		pr          *pipelinev1.PipelineRun
+		updateFunc  func(*pipelinev1.PipelineRun)
+		expectError bool
+	}{
+		{
+			name: "Successful update with annotation",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-1",
+					Namespace: "default",
+				},
+			},
+			updateFunc: func(pr *pipelinev1.PipelineRun) {
+				if pr.Annotations == nil {
+					pr.Annotations = make(map[string]string)
+				}
+				pr.Annotations["test-annotation"] = "true"
+			},
+			expectError: false,
+		},
+		{
+			name: "Update with label",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-2",
+					Namespace: "default",
+				},
+			},
+			updateFunc: func(pr *pipelinev1.PipelineRun) {
+				if pr.Labels == nil {
+					pr.Labels = make(map[string]string)
+				}
+				pr.Labels["updated"] = "true"
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			// Create fake client with PipelineRun
+			client := fakepipelineclientset.NewSimpleClientset(tt.pr)
+			prFuncs := NewPrFuncs(client)
+
+			// Apply update function
+			if tt.updateFunc != nil {
+				tt.updateFunc(tt.pr)
+			}
+
+			// Call Update
+			err := prFuncs.Update(ctx, tt.pr)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				// Verify the update
+				updated, err := client.TektonV1().PipelineRuns(tt.pr.Namespace).Get(ctx, tt.pr.Name, metav1.GetOptions{})
+				assert.NoError(t, err)
+				assert.Equal(t, tt.pr.Annotations, updated.Annotations)
+				assert.Equal(t, tt.pr.Labels, updated.Labels)
+			}
+		})
+	}
+}
+
+func TestGetCompletionTime(t *testing.T) {
+	now := metav1.Now()
+
+	tests := []struct {
+		name         string
+		pr           *pipelinev1.PipelineRun
+		expectedTime *metav1.Time
+	}{
+		{
+			name: "PipelineRun with completion time",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-1",
+					Namespace: "default",
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						CompletionTime: &now,
+					},
+				},
+			},
+			expectedTime: &now,
+		},
+		{
+			name: "PipelineRun without completion time",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-2",
+					Namespace: "default",
+				},
+			},
+			expectedTime: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			client := fakepipelineclientset.NewSimpleClientset(tt.pr)
+			prFuncs := NewPrFuncs(client)
+
+			// Call GetCompletionTime
+			completionTime, err := prFuncs.GetCompletionTime(tt.pr)
+
+			if tt.expectedTime == nil {
+				// When no completion time, expect error and zero time
+				assert.Error(t, err)
+				assert.True(t, completionTime.IsZero())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedTime.Time, completionTime.Time)
+			}
+		})
+	}
+}
+
+func TestIgnore(t *testing.T) {
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-1 * time.Hour))
+
+	tests := []struct {
+		name   string
+		pr     *pipelinev1.PipelineRun
+		expect bool
+	}{
+		{
+			name: "Completed PipelineRun should not be ignored",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						StartTime:      &earlier,
+						CompletionTime: &now,
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "Running PipelineRun should be ignored",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-2",
+					Namespace: "default",
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						StartTime: &earlier,
+					},
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			client := fakepipelineclientset.NewSimpleClientset(tt.pr)
+			prFuncs := NewPrFuncs(client)
+
+			// Call Ignore (cast to metav1.Object)
+			result := prFuncs.Ignore(metav1.Object(tt.pr))
+
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}

--- a/pkg/reconciler/taskrun/reconciler_additional_test.go
+++ b/pkg/reconciler/taskrun/reconciler_additional_test.go
@@ -1,0 +1,609 @@
+package taskrun
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	fakepipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestNewTrFuncs(t *testing.T) {
+	client := fakepipelineclientset.NewSimpleClientset()
+	trFuncs := NewTrFuncs(client)
+
+	assert.NotNil(t, trFuncs)
+	assert.NotNil(t, trFuncs.client)
+	assert.Equal(t, client, trFuncs.client)
+}
+
+func TestTaskRun_ListByLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		trs           []*pipelinev1.TaskRun
+		namespace     string
+		labels        map[string]string
+		expectedCount int
+	}{
+		{
+			name:      "No TaskRuns",
+			trs:       []*pipelinev1.TaskRun{},
+			namespace: "default",
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "Single matching TaskRun",
+			trs: []*pipelinev1.TaskRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Multiple matching TaskRuns",
+			trs: []*pipelinev1.TaskRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+							"env": "prod",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-2",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+							"env": "dev",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-3",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "other",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "No matching TaskRuns",
+			trs: []*pipelinev1.TaskRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "other",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			// Create fake client with TaskRuns
+			var runtimeObjs []runtime.Object
+			for _, tr := range tt.trs {
+				runtimeObjs = append(runtimeObjs, tr)
+			}
+			client := fakepipelineclientset.NewSimpleClientset(runtimeObjs...)
+			trFuncs := NewTrFuncs(client)
+
+			// Call ListByLabels
+			result, err := trFuncs.ListByLabels(ctx, tt.namespace, tt.labels)
+
+			assert.NoError(t, err)
+			assert.Len(t, result, tt.expectedCount)
+		})
+	}
+}
+
+func TestTaskRun_ListByAnnotations(t *testing.T) {
+	tests := []struct {
+		name          string
+		trs           []*pipelinev1.TaskRun
+		namespace     string
+		annotations   map[string]string
+		expectedCount int
+	}{
+		{
+			name:      "No TaskRuns",
+			trs:       []*pipelinev1.TaskRun{},
+			namespace: "default",
+			annotations: map[string]string{
+				"owner": "team-a",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "Single matching TaskRun",
+			trs: []*pipelinev1.TaskRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"owner": "team-a",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			annotations: map[string]string{
+				"owner": "team-a",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "Multiple matching TaskRuns",
+			trs: []*pipelinev1.TaskRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"owner":   "team-a",
+							"project": "myproject",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-2",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"owner":   "team-a",
+							"project": "otherproject",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-3",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"owner": "team-b",
+						},
+					},
+				},
+			},
+			namespace: "default",
+			annotations: map[string]string{
+				"owner": "team-a",
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			// Create fake client with TaskRuns
+			var runtimeObjs []runtime.Object
+			for _, tr := range tt.trs {
+				runtimeObjs = append(runtimeObjs, tr)
+			}
+			client := fakepipelineclientset.NewSimpleClientset(runtimeObjs...)
+			trFuncs := NewTrFuncs(client)
+
+			// Call ListByAnnotations
+			result, err := trFuncs.ListByAnnotations(ctx, tt.namespace, tt.annotations)
+
+			assert.NoError(t, err)
+			assert.Len(t, result, tt.expectedCount)
+		})
+	}
+}
+
+func TestTaskRun_ListByNamespaces(t *testing.T) {
+	tests := []struct {
+		name               string
+		trs                []*pipelinev1.TaskRun
+		namespaces         []string
+		expectedNamespaces int
+	}{
+		{
+			name:               "No namespaces",
+			trs:                []*pipelinev1.TaskRun{},
+			namespaces:         []string{},
+			expectedNamespaces: 0,
+		},
+		{
+			name: "Single namespace with TaskRuns",
+			trs: []*pipelinev1.TaskRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-1",
+						Namespace: "ns1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-2",
+						Namespace: "ns1",
+					},
+				},
+			},
+			namespaces:         []string{"ns1"},
+			expectedNamespaces: 1,
+		},
+		{
+			name: "Multiple namespaces",
+			trs: []*pipelinev1.TaskRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-1",
+						Namespace: "ns1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-2",
+						Namespace: "ns2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tr-3",
+						Namespace: "ns3",
+					},
+				},
+			},
+			namespaces:         []string{"ns1", "ns2", "ns3"},
+			expectedNamespaces: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			// Create fake client with TaskRuns
+			var runtimeObjs []runtime.Object
+			for _, tr := range tt.trs {
+				runtimeObjs = append(runtimeObjs, tr)
+			}
+			client := fakepipelineclientset.NewSimpleClientset(runtimeObjs...)
+			trFuncs := NewTrFuncs(client)
+
+			// Call ListByNamespaces
+			result, err := trFuncs.ListByNamespaces(ctx, tt.namespaces)
+
+			assert.NoError(t, err)
+			assert.Len(t, result, tt.expectedNamespaces)
+
+			// Verify each namespace has a result
+			for _, ns := range tt.namespaces {
+				_, exists := result[ns]
+				assert.True(t, exists, "Namespace %s should exist in results", ns)
+			}
+		})
+	}
+}
+
+func TestTaskRun_Update(t *testing.T) {
+	tests := []struct {
+		name        string
+		tr          *pipelinev1.TaskRun
+		updateFunc  func(*pipelinev1.TaskRun)
+		expectError bool
+	}{
+		{
+			name: "Successful update with annotation",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-1",
+					Namespace: "default",
+				},
+			},
+			updateFunc: func(tr *pipelinev1.TaskRun) {
+				if tr.Annotations == nil {
+					tr.Annotations = make(map[string]string)
+				}
+				tr.Annotations["test-annotation"] = "true"
+			},
+			expectError: false,
+		},
+		{
+			name: "Update with label",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-2",
+					Namespace: "default",
+				},
+			},
+			updateFunc: func(tr *pipelinev1.TaskRun) {
+				if tr.Labels == nil {
+					tr.Labels = make(map[string]string)
+				}
+				tr.Labels["updated"] = "true"
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			// Create fake client with TaskRun
+			client := fakepipelineclientset.NewSimpleClientset(tt.tr)
+			trFuncs := NewTrFuncs(client)
+
+			// Apply update function
+			if tt.updateFunc != nil {
+				tt.updateFunc(tt.tr)
+			}
+
+			// Call Update
+			err := trFuncs.Update(ctx, tt.tr)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				// Verify the update
+				updated, err := client.TektonV1().TaskRuns(tt.tr.Namespace).Get(ctx, tt.tr.Name, metav1.GetOptions{})
+				assert.NoError(t, err)
+				assert.Equal(t, tt.tr.Annotations, updated.Annotations)
+				assert.Equal(t, tt.tr.Labels, updated.Labels)
+			}
+		})
+	}
+}
+
+func TestTaskRun_GetCompletionTime(t *testing.T) {
+	now := metav1.Now()
+
+	tests := []struct {
+		name         string
+		tr           *pipelinev1.TaskRun
+		expectedTime *metav1.Time
+	}{
+		{
+			name: "TaskRun with completion time",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-1",
+					Namespace: "default",
+				},
+				Status: pipelinev1.TaskRunStatus{
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						CompletionTime: &now,
+					},
+				},
+			},
+			expectedTime: &now,
+		},
+		{
+			name: "TaskRun without completion time",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-2",
+					Namespace: "default",
+				},
+			},
+			expectedTime: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			client := fakepipelineclientset.NewSimpleClientset(tt.tr)
+			trFuncs := NewTrFuncs(client)
+
+			// Call GetCompletionTime
+			completionTime, err := trFuncs.GetCompletionTime(tt.tr)
+
+			if tt.expectedTime == nil {
+				// When no completion time, expect error and zero time
+				assert.Error(t, err)
+				assert.True(t, completionTime.IsZero())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedTime.Time, completionTime.Time)
+			}
+		})
+	}
+}
+
+func TestIsStandaloneTaskRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		tr       metav1.Object
+		expected bool
+	}{
+		{
+			name: "Standalone TaskRun without owner reference",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-1",
+					Namespace: "default",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "TaskRun with PipelineRun owner reference",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-2",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "tekton.dev/v1",
+							Kind:       "PipelineRun",
+							Name:       "pr-1",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "TaskRun with non-PipelineRun owner reference",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-3",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Pod",
+							Name:       "pod-1",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isStandaloneTaskRun(tt.tr)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTaskRun_Ignore(t *testing.T) {
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-1 * time.Hour))
+
+	tests := []struct {
+		name   string
+		tr     *pipelinev1.TaskRun
+		expect bool
+	}{
+		{
+			name: "Completed standalone TaskRun should not be ignored",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Status: pipelinev1.TaskRunStatus{
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						StartTime:      &earlier,
+						CompletionTime: &now,
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "Running TaskRun should be ignored",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-2",
+					Namespace: "default",
+				},
+				Status: pipelinev1.TaskRunStatus{
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						StartTime: &earlier,
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "TaskRun owned by PipelineRun should be ignored",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-3",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "tekton.dev/v1",
+							Kind:       "PipelineRun",
+							Name:       "pr-1",
+						},
+					},
+				},
+				Status: pipelinev1.TaskRunStatus{
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						StartTime:      &earlier,
+						CompletionTime: &now,
+					},
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := logtesting.TestLogger(t)
+			ctx = logging.WithLogger(ctx, logger)
+
+			client := fakepipelineclientset.NewSimpleClientset(tt.tr)
+			trFuncs := NewTrFuncs(client)
+
+			// Call Ignore (cast to metav1.Object)
+			result := trFuncs.Ignore(metav1.Object(tt.tr))
+
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,28 @@
+package version
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGet verifies version information is populated correctly from runtime.
+func TestGet(t *testing.T) {
+	v := Get()
+
+	assert.Equal(t, runtime.Version(), v.GoLang)
+	assert.Equal(t, runtime.GOOS, v.Platform)
+	assert.Equal(t, runtime.GOARCH, v.Arch)
+	assert.NotNil(t, v.Version)
+	assert.NotNil(t, v.GitCommit)
+	assert.NotNil(t, v.BuildDate)
+}
+
+// TestGetConsistency ensures Get returns consistent values across calls.
+func TestGetConsistency(t *testing.T) {
+	v1 := Get()
+	v2 := Get()
+
+	assert.Equal(t, v1, v2)
+}

--- a/pkg/webhook/configmapvalidation_test.go
+++ b/pkg/webhook/configmapvalidation_test.go
@@ -513,7 +513,7 @@ func TestValidateConfigMap_Admit_UpdateOperation(t *testing.T) {
 	}
 }
 
-func TestValidateConfigMap_Admit_InvalidJSON(t *testing.T) {
+func TestValidateConfigMap_Admit_InvalidJSONParsing(t *testing.T) {
 	req := &admissionv1.AdmissionRequest{
 		UID: "test-uid",
 		Kind: metav1.GroupVersionKind{
@@ -648,7 +648,7 @@ func TestValidateConfigMap_Admit_SystemMaximumEnforcement(t *testing.T) {
 	}
 }
 
-func TestValidateConfigMap_Path(t *testing.T) {
+func TestValidateConfigMap_Path_WithClient(t *testing.T) {
 	validator := &ValidateConfigMap{
 		Client:      fake.NewSimpleClientset(),
 		SecretName:  "test-secret",
@@ -718,7 +718,7 @@ func findSubstring(s, substr string) bool {
 	return false
 }
 
-func TestValidateNamespaceForConfig(t *testing.T) {
+func TestValidateNamespaceForConfig_AdditionalCases(t *testing.T) {
 	tests := []struct {
 		name      string
 		namespace string

--- a/versions.txt
+++ b/versions.txt
@@ -1,2 +1,2 @@
 # keep the next release version
-pruner=0.2.0
+pruner=0.3.3


### PR DESCRIPTION
# Changes

This pull request adds unit tests for several core packages, improving test coverage and reliability for configuration, metrics, versioning, and namespace pruner config reconciliation. 

**New test suites for core packages:**

* Added  unit tests for configuration loading, namespace config management, and concurrent access in `pkg/config/store_test.go`, verifying correct fallback logic and thread safety.
* Added  metrics tests in `pkg/metrics/metrics_test.go`, covering recorder initialization, event recording, error classification, and attribute construction.
* Added reconciliation and concurrency tests for namespace pruner config in `pkg/reconciler/namespaceprunerconfig/reconciler_additional_test.go`, including edge cases for config parsing and error handling.
* Updated `pruner` tracked version in `versions.txt` from `0.2.0` to `0.3.3`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [X] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind regression