### PR TITLE
[release-v0.3.x] chore(deps): bump the all group in /tekton with 4 updates

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -73,7 +73,7 @@ spec:
   steps:
 
   - name: container-registry-auth
-    image: cgr.dev/chainguard/crane:latest-dev@sha256:f830cdfc2950691e127aa30c0201874fdcff7365bac2e6f6c5419d777c224f4e
+    image: cgr.dev/chainguard/crane:latest-dev@sha256:8ddd1d98ec7f7652fa47e1d924ed3319948bb4eb77353256b3a09716c5cec0f7
     script: |
       #!/bin/sh
       set -ex
@@ -92,7 +92,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: create-ko-yaml
-    image: cgr.dev/chainguard/go:latest-dev@sha256:684525ff96884dd487f63426bfe64e2100f97816b06f7efdd9f8af61544ae850
+    image: cgr.dev/chainguard/go:latest-dev@sha256:9a227acc60c8f0dfd4658c2da4dec685a502e42312f2d25b7de5ca0d6f4b33c5
     script: |
       #!/bin/sh
       set -ex
@@ -130,7 +130,7 @@ spec:
       cat /workspace/.ko.yaml
 
   - name: run-ko
-    image: ghcr.io/tektoncd/plumbing/ko@sha256:286dc25c1c42761d2fabfb32366c99158702e5600ae4b793cfb834960a60b83e
+    image: ghcr.io/tektoncd/plumbing/ko@sha256:7c8c5cf57d83abc665d5330d0487f95b79da5f25ca7d125e5dc739d63ae081f9
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -197,7 +197,7 @@ spec:
       sed -i -e 's/\(pruner.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/release.notags.yaml
 
   - name: koparse
-    image: ghcr.io/tektoncd/plumbing/koparse@sha256:cafe51f7c2aa70257511f3ae4da1294a7630bd7f43fc0d1fd4027fef0b8400ac
+    image: ghcr.io/tektoncd/plumbing/koparse@sha256:955aed111ae9705182e3542e62300d92f890c470c1203639708e7f5835407586
     script: |
       set -ex
 
@@ -231,7 +231,7 @@ spec:
         ${PRESERVE_IMPORT_PATH} > /workspace/built_images
 
   - name: tag-images
-    image: cgr.dev/chainguard/crane:latest-dev@sha256:f830cdfc2950691e127aa30c0201874fdcff7365bac2e6f6c5419d777c224f4e
+    image: cgr.dev/chainguard/crane:latest-dev@sha256:8ddd1d98ec7f7652fa47e1d924ed3319948bb4eb77353256b3a09716c5cec0f7
     script: |
       #!/bin/sh
       set -ex


### PR DESCRIPTION
# Changes

Bumps the all group in /tekton with 4 updates: [chainguard/crane](https://github.com/chainguard-images/images), [chainguard/go](https://github.com/chainguard-images/images), tektoncd/plumbing/ko and tektoncd/plumbing/koparse.

Updates `chainguard/crane` from `f830cdf` to `8ddd1d9`
- [Commits](https://github.com/chainguard-images/images/commits)

Updates `chainguard/go` from `684525f` to `9a227ac`
- [Commits](https://github.com/chainguard-images/images/commits)

Updates `tektoncd/plumbing/ko` from `286dc25` to `7c8c5cf`

Updates `tektoncd/plumbing/koparse` from `cafe51f` to `955aed1`

---
updated-dependencies:
- dependency-name: chainguard/crane dependency-version: latest-dev dependency-type: direct:production dependency-group: all
- dependency-name: chainguard/go dependency-version: latest-dev dependency-type: direct:production dependency-group: all
- dependency-name: tektoncd/plumbing/ko dependency-version: 7c8c5cf57d83abc665d5330d0487f95b79da5f25ca7d125e5dc739d63ae081f9 dependency-type: direct:production dependency-group: all
- dependency-name: tektoncd/plumbing/koparse dependency-version: 955aed111ae9705182e3542e62300d92f890c470c1203639708e7f5835407586 dependency-type: direct:production dependency-group: all ...


(cherry picked from commit e9f0dc1a6fa7eb1d1210c1053c678f2fdb0711ec)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind misc