### PR TITLE
Remove tekton-* namespace exclusion from pruner

### DIFF
--- a/pkg/reconciler/tektonpruner/controller.go
+++ b/pkg/reconciler/tektonpruner/controller.go
@@ -145,7 +145,8 @@ func runGarbageCollector(ctx context.Context) {
 	logger.Info("Garbage collection completed")
 }
 
-// getFilteredNamespaces returns namespaces not starting with "kube" or "openshift"
+// getFilteredNamespaces returns namespaces excluding system namespaces
+// Excluded: kube-*, openshift-*, tekton-pipelines, tekton-operator
 func getFilteredNamespaces(ctx context.Context, client kubernetes.Interface) ([]string, error) {
 	nsList, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -155,7 +156,8 @@ func getFilteredNamespaces(ctx context.Context, client kubernetes.Interface) ([]
 	var filtered []string
 	for _, ns := range nsList.Items {
 		name := ns.Name
-		if !strings.HasPrefix(name, "kube") && !strings.HasPrefix(name, "openshift") && !strings.HasPrefix(name, "tekton") {
+		if !strings.HasPrefix(name, "kube-") && !strings.HasPrefix(name, "openshift-") &&
+			name != "tekton-pipelines" && name != "tekton-operator" {
 			filtered = append(filtered, name)
 		}
 	}

--- a/pkg/webhook/configmapvalidation.go
+++ b/pkg/webhook/configmapvalidation.go
@@ -74,7 +74,7 @@ func validateRequiredLabels(cm *corev1.ConfigMap) error {
 }
 
 // validateNamespaceForConfig checks if a namespace is allowed for namespace-level configs
-// Forbidden namespaces: kube-*, openshift-*, tekton-*
+// Forbidden namespaces: kube-*, openshift-*, tekton-pipelines, tekton-operator
 func validateNamespaceForConfig(namespace string) error {
 	if strings.HasPrefix(namespace, "kube-") {
 		return fmt.Errorf("namespace-level config cannot be created in kube-* namespaces, got: %s", namespace)
@@ -82,8 +82,8 @@ func validateNamespaceForConfig(namespace string) error {
 	if strings.HasPrefix(namespace, "openshift-") {
 		return fmt.Errorf("namespace-level config cannot be created in openshift-* namespaces, got: %s", namespace)
 	}
-	if strings.HasPrefix(namespace, "tekton-") {
-		return fmt.Errorf("namespace-level config cannot be created in tekton-* namespaces, got: %s", namespace)
+	if namespace == "tekton-pipelines" || namespace == "tekton-operator" {
+		return fmt.Errorf("namespace-level config cannot be created in %s namespace", namespace)
 	}
 	return nil
 }

--- a/pkg/webhook/configmapvalidation_test.go
+++ b/pkg/webhook/configmapvalidation_test.go
@@ -394,19 +394,18 @@ func TestValidateConfigMap_Admit_ForbiddenNamespaces(t *testing.T) {
 			name:        "tekton-pipelines namespace - forbidden",
 			namespace:   "tekton-pipelines",
 			wantAllowed: false,
-			wantMessage: "tekton-* namespaces",
+			wantMessage: "tekton-pipelines namespace",
 		},
 		{
 			name:        "tekton-operator namespace - forbidden",
 			namespace:   "tekton-operator",
 			wantAllowed: false,
-			wantMessage: "tekton-* namespaces",
+			wantMessage: "tekton-operator namespace",
 		},
 		{
-			name:        "tekton-custom namespace - forbidden",
+			name:        "tekton-custom namespace - allowed",
 			namespace:   "tekton-custom",
-			wantAllowed: false,
-			wantMessage: "tekton-* namespaces",
+			wantAllowed: true,
 		},
 		{
 			name:        "user namespace - allowed",
@@ -801,19 +800,18 @@ func TestValidateNamespaceForConfig_AdditionalCases(t *testing.T) {
 			name:      "forbidden tekton-pipelines",
 			namespace: "tekton-pipelines",
 			wantErr:   true,
-			errMsg:    "tekton-* namespaces",
+			errMsg:    "tekton-pipelines namespace",
 		},
 		{
 			name:      "forbidden tekton-operator",
 			namespace: "tekton-operator",
 			wantErr:   true,
-			errMsg:    "tekton-* namespaces",
+			errMsg:    "tekton-operator namespace",
 		},
 		{
-			name:      "forbidden tekton-custom",
+			name:      "allowed tekton-custom",
 			namespace: "tekton-custom",
-			wantErr:   true,
-			errMsg:    "tekton-* namespaces",
+			wantErr:   false,
 		},
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In the dogfooding cluster, there are user namespaces with the `tekton-*` prefix (e.g., `tekton-ci`). The previous restriction blocked **all** `tekton-*` namespaces, which prevented the cleanup job from processing these user namespaces and from creating namespace-level pruner configurations

This PR updates namespace filtering to only exclude the Tekton system namespaces like `tekton-pipelines` and `tekton-operator` and other `tekton-*` namespaces are now allowed.

Fixes: #105 

/kind bug
/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Allow `tekton-*` namespaces to be processed by the pruner, except tekton-pipelines and tekton-operator.
```
