### PR TITLE
feat: add cherry-pick slash command workflow

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -1,0 +1,32 @@
+# Cherry Pick Command Workflow
+#
+# This workflow is triggered by the /cherry-pick slash command from the slash.yml workflow.
+# It automatically cherry-picks merged PRs to the specified target branches.
+#
+# Usage: Comment `/cherry-pick <target-branch> [<target-branch> ...]` on a merged pull request
+# Example: `/cherry-pick release-v0.3.x`
+# Example: `/cherry-pick release-v0.3.x release-v0.4.x`
+#
+# Security Notes:
+# - Only users with "write" permission can trigger this command (enforced in slash.yml)
+# - Works safely with PRs from forks because it only cherry-picks already-merged commits
+# - Uses CHATOPS_TOKEN to create PRs and push to branches
+# - The action creates a new branch from the target branch, not from the fork
+
+name: Cherry Pick Command
+
+on:
+  repository_dispatch:
+    types: [cherry-pick-command]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  cherry-pick:
+    name: Cherry Pick Actions
+    uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@4b57443b85569e5bb7d9ee440bf5cae99cb642cb
+    secrets:
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -1,0 +1,40 @@
+# The slash workflow handles slash commands
+#
+# Slash commands are given through comments on pull requests
+# and may be used only by individuals with "write" access to
+# the repository (i.e. maintainers).
+#
+# Slash commands must be placed at the very beginning of the
+# first line of a comment. More details are available in the
+# action docs: https://github.com/peter-evans/slash-command-dispatch/tree/main?tab=readme-ov-file#how-comments-are-parsed-for-slash-commands
+#
+# The workflow looks for and dispatches to another workflow
+# named <command>-command which must exist in the repository.
+#
+# Supported commands:
+# - /cherry-pick <branch>: cherry-picks the merged PR to the specified branch
+#
+# When a command is recognised, the rocket and eyes emojis are added
+
+name: Slash Command Routing
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check_comments:
+    runs-on: ubuntu-latest
+    steps:
+    - name: route-slash-commands
+      uses: peter-evans/slash-command-dispatch@5c11dc7efead556e3bdabf664302212f79eb26fa # v5.0.1
+      with:
+        token: ${{ secrets.CHATOPS_TOKEN }}
+        config: >
+          [
+            {
+              "command": "cherry-pick",
+              "permission": "write",
+              "issue_type": "pull-request",
+              "repository": "tektoncd/pruner"
+            }
+          ]


### PR DESCRIPTION
# Changes

This PR adds the cherry-pick slash command workflow to pruner (addresses tektoncd/plumbing#3004).

**What's included:**
- New `slash.yml` workflow to enable slash commands on PRs
- New `cherry-pick-command.yaml` workflow using the centralized plumbing reusable workflow
- Enables `/cherry-pick <branch>` command for easier backports to release branches

**Benefits:**
- Streamlines cherry-picking to release branches with simple slash command
- Uses centralized, well-tested logic from tektoncd/plumbing
- Consistent behavior with other tektoncd repositories
- Reduces manual cherry-pick errors

**Usage:**
Comment `/cherry-pick release-v0.3.x` on a merged PR to automatically create a cherry-pick PR to that branch.

# Submitter Checklist

- [x] Includes tests (N/A - workflow files only)
- [x] Includes docs (comprehensive inline documentation in workflow files)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
NONE
```