### PR TITLE
chore: add omitempty to YAML/JSON struct tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,7 +67,7 @@ const (
 // ResourceSpec is used to hold the config of a specific resource
 // Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
 type ResourceSpec struct {
-	Name         string         `yaml:"name"`               // Exact name of the parent Pipeline or Task
+	Name         string         `yaml:"name,omitempty"`     // Exact name of the parent Pipeline or Task
 	Selector     []SelectorSpec `yaml:"selector,omitempty"` // Supports selection based on labels and annotations. If Name is given, Name takes precedence
 	PrunerConfig `yaml:",inline"`
 }
@@ -85,8 +85,8 @@ type SelectorSpec struct {
 // Selector support (PipelineRuns/TaskRuns arrays) ONLY works in namespace ConfigMaps
 type NamespaceSpec struct {
 	PrunerConfig `yaml:",inline"` // Root-level defaults
-	PipelineRuns []ResourceSpec   `yaml:"pipelineRuns"` // Selector-based configs (namespace ConfigMap only)
-	TaskRuns     []ResourceSpec   `yaml:"taskRuns"`     // Selector-based configs (namespace ConfigMap only)
+	PipelineRuns []ResourceSpec   `yaml:"pipelineRuns,omitempty"` // Selector-based configs (namespace ConfigMap only)
+	TaskRuns     []ResourceSpec   `yaml:"taskRuns,omitempty"`     // Selector-based configs (namespace ConfigMap only)
 }
 
 // GlobalConfig represents the global ConfigMap (tekton-pruner-default-spec)
@@ -94,17 +94,17 @@ type NamespaceSpec struct {
 // NOTE: Selector support (PipelineRuns/TaskRuns arrays) is IGNORED in global ConfigMap
 type GlobalConfig struct {
 	PrunerConfig `yaml:",inline"`         // Global root-level defaults
-	Namespaces   map[string]NamespaceSpec `yaml:"namespaces"  json:"namespaces"` // Per-namespace defaults (selectors ignored)
+	Namespaces   map[string]NamespaceSpec `yaml:"namespaces,omitempty" json:"namespaces,omitempty"` // Per-namespace defaults (selectors ignored)
 }
 
 // PrunerConfig used to hold the cluster-wide pruning config as well as namespace specific pruning config
 type PrunerConfig struct {
-	// EnforcedConfigLevel allowed values: global, namespace, resource (default: resource)
-	EnforcedConfigLevel     *EnforcedConfigLevel `yaml:"enforcedConfigLevel" json:"enforcedConfigLevel"`
-	TTLSecondsAfterFinished *int32               `yaml:"ttlSecondsAfterFinished" json:"ttlSecondsAfterFinished"`
-	SuccessfulHistoryLimit  *int32               `yaml:"successfulHistoryLimit" json:"successfulHistoryLimit"`
-	FailedHistoryLimit      *int32               `yaml:"failedHistoryLimit" json:"failedHistoryLimit"`
-	HistoryLimit            *int32               `yaml:"historyLimit" json:"historyLimit"`
+	// EnforcedConfigLevel allowed values: global, namespace (default: namespace)
+	EnforcedConfigLevel     *EnforcedConfigLevel `yaml:"enforcedConfigLevel,omitempty" json:"enforcedConfigLevel,omitempty"`
+	TTLSecondsAfterFinished *int32               `yaml:"ttlSecondsAfterFinished,omitempty" json:"ttlSecondsAfterFinished,omitempty"`
+	SuccessfulHistoryLimit  *int32               `yaml:"successfulHistoryLimit,omitempty" json:"successfulHistoryLimit,omitempty"`
+	FailedHistoryLimit      *int32               `yaml:"failedHistoryLimit,omitempty" json:"failedHistoryLimit,omitempty"`
+	HistoryLimit            *int32               `yaml:"historyLimit,omitempty" json:"historyLimit,omitempty"`
 }
 
 // prunerConfigStore defines the store structure to hold config from ConfigMap


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
When setting namespace-level config for TektonPruner, unset fields (PipelineRuns, TaskRuns, enforcedConfigLevel, etc.) were being written as `null` in the YAML output.

This PR adds `omitempty` to ensure nil/empty fields are omitted when marshaling to YAML/JSON, resulting in cleaner configuration output.

/kind cleanup

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Namespace config no longer shows null values for unset fields in TektonPruner global-config
```
