### PR TITLE
fix: selector-based pruning for label and annotation selectors

### DIFF
--- a/pkg/config/history_limiter_test.go
+++ b/pkg/config/history_limiter_test.go
@@ -99,6 +99,10 @@ func (m *mockResourceFuncs) GetEnforcedConfigLevel(_, _ string, _ SelectorSpec) 
 	return m.enforceLevel
 }
 
+func (m *mockResourceFuncs) GetMatchingSelector(_, _ string, _ SelectorSpec) *SelectorSpec {
+	return nil // Return nil to list all resources in namespace for tests
+}
+
 func TestNewHistoryLimiter(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/reconciler/pipelinerun/reconciler.go
+++ b/pkg/reconciler/pipelinerun/reconciler.go
@@ -452,3 +452,8 @@ func (prf *PrFuncs) GetFailedHistoryLimitCount(namespace, name string, selectors
 func (prf *PrFuncs) GetEnforcedConfigLevel(namespace, name string, selectors config.SelectorSpec) config.EnforcedConfigLevel {
 	return config.PrunerConfigStore.GetPipelineEnforcedConfigLevel(namespace, name, selectors)
 }
+
+// GetMatchingSelector returns the ConfigMap's selector that matches a PipelineRun.
+func (prf *PrFuncs) GetMatchingSelector(namespace, name string, selectors config.SelectorSpec) *config.SelectorSpec {
+	return config.PrunerConfigStore.GetPipelineMatchingSelector(namespace, name, selectors)
+}

--- a/pkg/reconciler/taskrun/reconciler.go
+++ b/pkg/reconciler/taskrun/reconciler.go
@@ -444,3 +444,8 @@ func (trf *TrFuncs) GetFailedHistoryLimitCount(namespace, name string, selectors
 func (trf *TrFuncs) GetEnforcedConfigLevel(namespace, name string, selectors config.SelectorSpec) config.EnforcedConfigLevel {
 	return config.PrunerConfigStore.GetTaskEnforcedConfigLevel(namespace, name, selectors)
 }
+
+// GetMatchingSelector returns the ConfigMap's selector that matches a TaskRun.
+func (trf *TrFuncs) GetMatchingSelector(namespace, name string, selectors config.SelectorSpec) *config.SelectorSpec {
+	return config.PrunerConfigStore.GetTaskMatchingSelector(namespace, name, selectors)
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR fixes a bug in selector-based pruning where PipelineRuns were not being grouped correctly when using `matchLabels` or `matchAnnotations` in namespace-level ConfigMaps.

### Problem

**Label selectors:** When a ConfigMap specified `matchLabels: {env: test}`, the pruner was using ALL labels from the PipelineRun to list resources, including Tekton-generated labels like `tekton.dev/pipeline`. This meant each PipelineRun was treated as its own unique group.

**Annotation selectors:** When a ConfigMap specified only `matchAnnotations`, the list selector became empty, causing all the resources in the namespace to be listed and the configuration to be applied incorrectly to unrelated PipelineRuns.

### Solution

1. Added `GetMatchingSelector()` method to retrieve the exact selector from the ConfigMap that matched the resource
2. Modified `doResourceCleanup()` to use only the ConfigMap's `matchLabels`

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
/kind bug
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Selector-based pruning now correctly group PipelineRuns by ConfigMap-defined labels/annotations instead of all resource labels
```
