### PR TITLE
tekton: automate releases with Pipelines-as-Code

### DIFF
--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -1,0 +1,177 @@
+name: Patch Release
+
+"on":
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch (e.g. release-v0.3.x)"
+        required: true
+        type: string
+      version:
+        description: "Version to release (e.g. v0.3.6)"
+        required: true
+        type: string
+      release_as_latest:
+        description: "Publish as latest release"
+        required: false
+        type: boolean
+        default: true
+  schedule:
+    # Weekly on Thursday at 10:00 UTC
+    - cron: "0 10 * * 4"
+
+env:
+  PAC_CONTROLLER_URL: "https://pac.infra.tekton.dev"
+  PAC_REPOSITORY_NAME: "tektoncd-pruner"
+  # Ignore release branches older than this (major.minor)
+  MIN_RELEASE_VERSION: "0.3"
+
+jobs:
+  scan-release-branches:
+    name: Scan for unreleased commits
+    if: github.event_name == 'schedule' && github.repository_owner == 'tektoncd'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scan.outputs.matrix }}
+      has_releases: ${{ steps.scan.outputs.has_releases }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Scan release branches for new commits
+        id: scan
+        run: |
+          # Determine which release branch is the latest (highest version)
+          latest_branch=""
+          latest_major=0
+          latest_minor=0
+          for ref in $(git branch -r --list 'origin/release-v*'); do
+            branch="${ref#origin/}"
+            if [[ "$branch" =~ release-v([0-9]+)\.([0-9]+)\.x ]]; then
+              major="${BASH_REMATCH[1]}"
+              minor="${BASH_REMATCH[2]}"
+              if [ "$major" -gt "$latest_major" ] || { [ "$major" -eq "$latest_major" ] && [ "$minor" -gt "$latest_minor" ]; }; then
+                latest_major=$major
+                latest_minor=$minor
+                latest_branch=$branch
+              fi
+            fi
+          done
+          echo "::notice::Latest release branch: ${latest_branch}"
+
+          MIN_MAJOR="${MIN_RELEASE_VERSION%%.*}"
+          MIN_MINOR="${MIN_RELEASE_VERSION##*.}"
+
+          releases=()
+          for ref in $(git branch -r --list 'origin/release-v*'); do
+            branch="${ref#origin/}"
+
+            # Skip branches older than MIN_RELEASE_VERSION
+            if [[ "$branch" =~ release-v([0-9]+)\.([0-9]+)\.x ]]; then
+              major="${BASH_REMATCH[1]}"
+              minor="${BASH_REMATCH[2]}"
+              if [ "$major" -lt "$MIN_MAJOR" ] || { [ "$major" -eq "$MIN_MAJOR" ] && [ "$minor" -lt "$MIN_MINOR" ]; }; then
+                echo "::notice::Branch ${branch} is older than v${MIN_RELEASE_VERSION} — skipping"
+                continue
+              fi
+            fi
+
+            # Find the latest tag on this branch
+            last_tag=$(git describe --tags --abbrev=0 --match 'v*' "$ref" 2>/dev/null || echo "")
+            if [ -z "$last_tag" ]; then
+              echo "::notice::Branch ${branch} has no tags — skipping (initial release handled by branch creation)"
+              continue
+            fi
+
+            # Count commits since last tag
+            new_commits=$(git rev-list "${last_tag}..${ref}" --count)
+            if [ "$new_commits" -eq 0 ]; then
+              echo "::notice::Branch ${branch} has no new commits since ${last_tag}"
+              continue
+            fi
+
+            # Calculate next patch version: v0.3.5 → v0.3.6
+            next_version=$(echo "$last_tag" | awk -F. '{printf "%s.%s.%d", $1, $2, $3+1}')
+
+            # Only the latest release branch publishes as latest
+            is_latest="false"
+            if [ "$branch" = "$latest_branch" ]; then
+              is_latest="true"
+            fi
+
+            echo "::notice::Branch ${branch}: ${new_commits} new commits since ${last_tag} → ${next_version} (latest=${is_latest})"
+            releases+=("{\"branch\":\"${branch}\",\"version\":\"${next_version}\",\"release_as_latest\":\"${is_latest}\"}")
+          done
+
+          if [ ${#releases[@]} -eq 0 ]; then
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+            echo "has_releases=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[$(IFS=,; echo "${releases[*]}")]" >> "$GITHUB_OUTPUT"
+            echo "has_releases=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  trigger-scanned-releases:
+    name: "Trigger ${{ matrix.release.version }} (${{ matrix.release.branch }})"
+    needs: scan-release-branches
+    if: needs.scan-release-branches.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: ${{ fromJson(needs.scan-release-branches.outputs.matrix) }}
+      max-parallel: 1
+    steps:
+      - name: Trigger PAC incoming webhook
+        env:
+          PAC_INCOMING_SECRET: ${{ secrets.PAC_INCOMING_SECRET }}
+        run: |
+          echo "::notice::Triggering release ${{ matrix.release.version }} on ${{ matrix.release.branch }} (latest=${{ matrix.release.release_as_latest }})"
+          curl -sf -X POST "${PAC_CONTROLLER_URL}/incoming" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "repository": "'"${PAC_REPOSITORY_NAME}"'",
+              "branch": "${{ matrix.release.branch }}",
+              "pipelinerun": "release-patch",
+              "secret": "'"${PAC_INCOMING_SECRET}"'",
+              "params": {
+                "version": "${{ matrix.release.version }}",
+                "release_as_latest": "${{ matrix.release.release_as_latest }}"
+              }
+            }'
+          echo "Release triggered successfully"
+
+  trigger-manual-release:
+    name: "Trigger ${{ inputs.version }} (${{ inputs.branch }})"
+    if: github.event_name == 'workflow_dispatch' && github.repository_owner == 'tektoncd'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs
+        run: |
+          if [[ ! "${{ inputs.branch }}" =~ ^release-v[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error::Invalid branch format: ${{ inputs.branch }}. Expected: release-vX.Y.x"
+            exit 1
+          fi
+          if [[ ! "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${{ inputs.version }}. Expected: vX.Y.Z"
+            exit 1
+          fi
+
+      - name: Trigger PAC incoming webhook
+        env:
+          PAC_INCOMING_SECRET: ${{ secrets.PAC_INCOMING_SECRET }}
+        run: |
+          echo "::notice::Triggering release ${{ inputs.version }} on ${{ inputs.branch }} (latest=${{ inputs.release_as_latest }})"
+          curl -sf -X POST "${PAC_CONTROLLER_URL}/incoming" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "repository": "'"${PAC_REPOSITORY_NAME}"'",
+              "branch": "${{ inputs.branch }}",
+              "pipelinerun": "release-patch",
+              "secret": "'"${PAC_INCOMING_SECRET}"'",
+              "params": {
+                "version": "${{ inputs.version }}",
+                "release_as_latest": "${{ inputs.release_as_latest }}"
+              }
+            }'
+          echo "Release triggered successfully"

--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -1,0 +1,187 @@
+name: Patch Release
+
+"on":
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch (e.g. release-v0.3.x)"
+        required: true
+        type: string
+      version:
+        description: "Version to release (e.g. v0.3.6)"
+        required: true
+        type: string
+      release_as_latest:
+        description: "Publish as latest release"
+        required: false
+        type: boolean
+        default: true
+  schedule:
+    # Weekly on Thursday at 10:00 UTC
+    - cron: "0 10 * * 4"
+
+permissions:
+  contents: read
+
+env:
+  PAC_CONTROLLER_URL: "https://pac.infra.tekton.dev"
+  PAC_REPOSITORY_NAME: "tektoncd-pruner"
+  # Ignore release branches older than this (major.minor)
+  MIN_RELEASE_VERSION: "0.3"
+
+jobs:
+  scan-release-branches:
+    name: Scan for unreleased commits
+    if: github.event_name == 'schedule' && github.repository_owner == 'tektoncd'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scan.outputs.matrix }}
+      has_releases: ${{ steps.scan.outputs.has_releases }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Scan release branches for new commits
+        id: scan
+        run: |
+          # Determine which release branch is the latest (highest version)
+          latest_branch=""
+          latest_major=0
+          latest_minor=0
+          for ref in $(git branch -r --list 'origin/release-v*'); do
+            branch="${ref#origin/}"
+            if [[ "$branch" =~ release-v([0-9]+)\.([0-9]+)\.x ]]; then
+              major="${BASH_REMATCH[1]}"
+              minor="${BASH_REMATCH[2]}"
+              if [ "$major" -gt "$latest_major" ] || { [ "$major" -eq "$latest_major" ] && [ "$minor" -gt "$latest_minor" ]; }; then
+                latest_major=$major
+                latest_minor=$minor
+                latest_branch=$branch
+              fi
+            fi
+          done
+          echo "::notice::Latest release branch: ${latest_branch}"
+
+          MIN_MAJOR="${MIN_RELEASE_VERSION%%.*}"
+          MIN_MINOR="${MIN_RELEASE_VERSION##*.}"
+
+          releases=()
+          for ref in $(git branch -r --list 'origin/release-v*'); do
+            branch="${ref#origin/}"
+
+            # Skip branches older than MIN_RELEASE_VERSION
+            if [[ "$branch" =~ release-v([0-9]+)\.([0-9]+)\.x ]]; then
+              major="${BASH_REMATCH[1]}"
+              minor="${BASH_REMATCH[2]}"
+              if [ "$major" -lt "$MIN_MAJOR" ] || { [ "$major" -eq "$MIN_MAJOR" ] && [ "$minor" -lt "$MIN_MINOR" ]; }; then
+                echo "::notice::Branch ${branch} is older than v${MIN_RELEASE_VERSION} — skipping"
+                continue
+              fi
+            fi
+
+            # Find the latest tag on this branch
+            last_tag=$(git describe --tags --abbrev=0 --match 'v*' "$ref" 2>/dev/null || echo "")
+            if [ -z "$last_tag" ]; then
+              echo "::notice::Branch ${branch} has no tags — skipping (initial release handled by branch creation)"
+              continue
+            fi
+
+            # Count commits since last tag
+            new_commits=$(git rev-list "${last_tag}..${ref}" --count)
+            if [ "$new_commits" -eq 0 ]; then
+              echo "::notice::Branch ${branch} has no new commits since ${last_tag}"
+              continue
+            fi
+
+            # Calculate next patch version: v0.3.5 → v0.3.6
+            next_version=$(echo "$last_tag" | awk -F. '{printf "%s.%s.%d", $1, $2, $3+1}')
+
+            # Only the latest release branch publishes as latest
+            is_latest="false"
+            if [ "$branch" = "$latest_branch" ]; then
+              is_latest="true"
+            fi
+
+            echo "::notice::Branch ${branch}: ${new_commits} new commits since ${last_tag} → ${next_version} (latest=${is_latest})"
+            releases+=("{\"branch\":\"${branch}\",\"version\":\"${next_version}\",\"release_as_latest\":\"${is_latest}\"}")
+          done
+
+          if [ ${#releases[@]} -eq 0 ]; then
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+            echo "has_releases=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[$(IFS=,; echo "${releases[*]}")]" >> "$GITHUB_OUTPUT"
+            echo "has_releases=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  trigger-scanned-releases:
+    name: "Trigger ${{ matrix.release.version }} (${{ matrix.release.branch }})"
+    needs: scan-release-branches
+    if: needs.scan-release-branches.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: ${{ fromJson(needs.scan-release-branches.outputs.matrix) }}
+      max-parallel: 1
+    steps:
+      - name: Trigger PAC incoming webhook
+        env:
+          PAC_INCOMING_SECRET: ${{ secrets.PAC_INCOMING_SECRET }}
+        run: |
+          echo "::notice::Triggering release ${{ matrix.release.version }} on ${{ matrix.release.branch }} (latest=${{ matrix.release.release_as_latest }})"
+          curl -sf -X POST "${PAC_CONTROLLER_URL}/incoming" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "repository": "'"${PAC_REPOSITORY_NAME}"'",
+              "branch": "${{ matrix.release.branch }}",
+              "pipelinerun": "release-patch",
+              "secret": "'"${PAC_INCOMING_SECRET}"'",
+              "params": {
+                "version": "${{ matrix.release.version }}",
+                "release_as_latest": "${{ matrix.release.release_as_latest }}"
+              }
+            }'
+          echo "Release triggered successfully"
+
+  trigger-manual-release:
+    name: "Trigger ${{ inputs.version }} (${{ inputs.branch }})"
+    if: github.event_name == 'workflow_dispatch' && github.repository_owner == 'tektoncd'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs
+        env:
+          BRANCH: ${{ inputs.branch }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "${BRANCH}" =~ ^release-v[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error::Invalid branch format: ${BRANCH}. Expected: release-vX.Y.x"
+            exit 1
+          fi
+          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${VERSION}. Expected: vX.Y.Z"
+            exit 1
+          fi
+
+      - name: Trigger PAC incoming webhook
+        env:
+          PAC_INCOMING_SECRET: ${{ secrets.PAC_INCOMING_SECRET }}
+          BRANCH: ${{ inputs.branch }}
+          VERSION: ${{ inputs.version }}
+          RELEASE_AS_LATEST: ${{ inputs.release_as_latest }}
+        run: |
+          echo "::notice::Triggering release ${VERSION} on ${BRANCH} (latest=${RELEASE_AS_LATEST})"
+          curl -sf -X POST "${PAC_CONTROLLER_URL}/incoming" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "repository": "'"${PAC_REPOSITORY_NAME}"'",
+              "branch": "'"${BRANCH}"'",
+              "pipelinerun": "release-patch",
+              "secret": "'"${PAC_INCOMING_SECRET}"'",
+              "params": {
+                "version": "'"${VERSION}"'",
+                "release_as_latest": "'"${RELEASE_AS_LATEST}"'"
+              }
+            }'
+          echo "Release triggered successfully"

--- a/.tekton/release-patch.yaml
+++ b/.tekton/release-patch.yaml
@@ -1,0 +1,83 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This PipelineRun is triggered via PAC incoming webhooks for patch
+# releases on existing release branches. It is invoked either manually
+# (via GitHub Actions workflow_dispatch) or on a cron schedule when
+# new commits are detected on a release branch since the last tag.
+#
+# The version and release_as_latest parameters are passed dynamically
+# through the incoming webhook payload.
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: release-patch
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[incoming]"
+    pipelinesascode.tekton.dev/on-target-branch: "[release-v*]"
+    pipelinesascode.tekton.dev/pipeline: "tekton/release-pipeline.yaml"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  taskRunTemplate:
+    serviceAccountName: release
+  pipelineRef:
+    name: pruner-release
+  params:
+    - name: package
+      value: github.com/tektoncd/pruner
+    - name: repoName
+      value: pruner
+    - name: gitRevision
+      value: "{{ revision }}"
+    - name: imageRegistry
+      value: ghcr.io
+    - name: imageRegistryPath
+      value: tektoncd/pruner
+    - name: imageRegistryRegions
+      value: ""
+    - name: imageRegistryUser
+      value: tekton-robot
+    - name: versionTag
+      value: "{{ version }}"
+    - name: releaseBucket
+      value: tekton-releases
+    - name: releaseAsLatest
+      value: "{{ release_as_latest }}"
+    - name: buildPlatforms
+      value: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+    - name: publishPlatforms
+      value: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    - name: koExtraArgs
+      value: ""
+    - name: serviceAccountImagesPath
+      value: credentials
+    - name: runTests
+      value: "true"
+  timeouts:
+    pipeline: 3h0m0s
+  workspaces:
+    - name: workarea
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - name: release-secret
+      secret:
+        secretName: oci-release-secret
+    - name: release-images-secret
+      secret:
+        secretName: ghcr-creds

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -1,0 +1,92 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This PipelineRun is triggered by Pipelines-as-Code when a release
+# branch (release-v*) is first created. It runs the pruner release
+# pipeline defined in tekton/release-pipeline.yaml.
+#
+# The release pipeline builds, publishes multi-arch images, uploads
+# artifacts to the release bucket, and reports the release URLs.
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: release-pipeline
+  annotations:
+    # Trigger on push events to release branches, but ONLY when the branch
+    # is first created (body.created == true). This means it fires exactly
+    # once per release branch, not on every commit pushed to it.
+    # NOTE: on-cel-expression takes precedence over on-event/on-target-branch,
+    # so the branch filter MUST be included in the CEL expression.
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/release-v*]"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && has(body.created) && body.created == true &&
+      target_branch.startsWith("release-v")
+    pipelinesascode.tekton.dev/pipeline: "tekton/release-pipeline.yaml"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  taskRunTemplate:
+    serviceAccountName: release
+  pipelineRef:
+    name: pruner-release
+  params:
+    - name: package
+      value: github.com/tektoncd/pruner
+    - name: repoName
+      value: pruner
+    - name: gitRevision
+      value: "{{ revision }}"
+    - name: imageRegistry
+      value: ghcr.io
+    - name: imageRegistryPath
+      value: tektoncd/pruner
+    - name: imageRegistryRegions
+      value: ""
+    - name: imageRegistryUser
+      value: tekton-robot
+    # For initial releases, the version is derived from the branch name:
+    # release-v0.3.x → v0.3.0
+    - name: versionTag
+      value: '{{ cel: pac.target_branch.replace("release-", "").replace(".x", ".0") }}'
+    - name: releaseBucket
+      value: tekton-releases
+    - name: releaseAsLatest
+      value: "true"
+    - name: buildPlatforms
+      value: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+    - name: publishPlatforms
+      value: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    - name: koExtraArgs
+      value: ""
+    - name: serviceAccountImagesPath
+      value: credentials
+    - name: runTests
+      value: "true"
+  timeouts:
+    pipeline: 3h0m0s
+  workspaces:
+    - name: workarea
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - name: release-secret
+      secret:
+        secretName: oci-release-secret
+    - name: release-images-secret
+      secret:
+        secretName: ghcr-creds

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -1,115 +1,58 @@
 # Tekton Pruner Official Release Cheat Sheet
 
 These steps provide a no-frills guide to performing an official release
-of Tekton Pruner. To follow these steps you'll need a checkout of
-the pruner repo, a terminal window and a text editor.
+of Tekton Pruner. Releases are now largely automated via
+[Pipelines-as-Code](https://pipelinesascode.com) (PAC) on the `oci-ci-cd`
+cluster.
 
-1. [Setup a context to connect to the dogfooding cluster](#setup-dogfooding-context) if you haven't already.
+## How releases work
 
-1. Install the [rekor CLI](https://docs.sigstore.dev/rekor/installation/) if you haven't already.
+### Initial releases (e.g. v0.4.0)
 
-1. `cd` to root of Pruner git checkout.
+1. Create a release branch named `release-v<major>.<minor>.x` (e.g.
+   `release-v0.4.x`) from the desired commit on `main`.
+2. PAC automatically detects the branch creation and triggers the release
+   pipeline defined in `.tekton/release.yaml`.
+3. The version is derived from the branch name: `release-v0.4.x` → `v0.4.0`.
+4. Monitor the PipelineRun on the
+   [Tekton Dashboard](https://tekton.infra.tekton.dev/#/namespaces/releases-pruner/pipelineruns).
 
-1. [Install kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize) if you haven't already.
+### Patch releases (e.g. v0.3.6)
 
-1. Select the commit you would like to build the release from (NOTE: the commit is full (40-digit) hash.)
-    - Select the most recent commit on the ***main branch*** if you are cutting a major or minor release i.e. `x.0.0` or `0.x.0`
-    - Select the most recent commit on the ***`release-<version number>x` branch***, e.g. [`release-v0.3.x`](https://github.com/tektoncd/pruner/tree/release-v0.3.x) if you are patching a release i.e. `v0.3.4`.
+Patch releases happen in two ways:
 
-1. Ensure the correct version of the release pipeline is installed on the cluster.
-   To do that, the selected commit should be checked-out locally
+- **Automatically**: A weekly cron (Thursday 10:00 UTC) in
+  `.github/workflows/patch-release.yaml` scans all `release-v*` branches.
+  If new commits exist since the last tag, it triggers a patch release via
+  PAC incoming webhook.
+- **Manually**: Run the "Patch Release" workflow from GitHub Actions
+  (`workflow_dispatch`) with the branch and version as inputs.
 
-    ```bash
-    kustomize build tekton | kubectl --context dogfooding replace -f -
+Both methods trigger the release pipeline defined in `.tekton/release-patch.yaml`
+on the `oci-ci-cd` cluster.
+
+## Post-release steps
+
+Once the release pipeline completes successfully:
+
+1. Check the PipelineRun results on the
+   [Tekton Dashboard](https://tekton.infra.tekton.dev/#/namespaces/releases-pruner/pipelineruns):
+
     ```
-
-1. Create a `release.env` file with environment variables for bash scripts in later steps, and source it:
-
-    ```bash
-    cat <<EOF > release.env
-    PRUNER_VERSION= # Example: v0.3.4
-    PRUNER_RELEASE_GIT_SHA= # SHA of the release to be released, e.g. 5b082b1106753e093593d12152c82e1c4b0f37e5
-    PRUNER_OLD_VERSION= # Example: v0.3.3
-    TEKTON_PACKAGE=tektoncd/pruner
-    PRUNER_REPO_NAME=pruner
-    EOF
-    . ./release.env
-    ```
-
-1. Confirm commit SHA matches what you want to release.
-
-    ```bash
-    git show $PRUNER_RELEASE_GIT_SHA
-    ```
-
-1. Create a workspace template file:
-
-   ```bash
-   WORKSPACE_TEMPLATE=$(mktemp /tmp/workspace-template.XXXXXX.yaml)
-   cat <<'EOF' > $WORKSPACE_TEMPLATE
-   spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi
-   EOF
-   ```
-
-1. Execute the release pipeline.
-    
-    **The minimum required tkn version is v0.30.0 or later**
-
-    **If you are back-porting include this flag: `--param=releaseAsLatest="false"`**
-
-   ```bash
-    tkn --context dogfooding pipeline start pruner-release \
-      --param package=github.com/tektoncd/pruner \
-      --param repoName="${PRUNER_REPO_NAME}" \
-      --param gitRevision="${PRUNER_RELEASE_GIT_SHA}" \
-      --param imageRegistry=ghcr.io \
-      --param imageRegistryPath=tektoncd/pruner \
-      --param imageRegistryRegions="" \
-      --param imageRegistryUser=tekton-robot \
-      --param serviceAccountImagesPath=credentials \
-      --param versionTag="${PRUNER_VERSION}" \
-      --param releaseBucket=tekton-releases \
-      --param koExtraArgs="" \
-      --workspace name=release-secret,secret=oci-release-secret \
-      --workspace name=release-images-secret,secret=ghcr-creds \
-      --workspace name=workarea,volumeClaimTemplateFile="${WORKSPACE_TEMPLATE}" \
-      --tasks-timeout 2h \
-      --pipeline-timeout 3h
-   ```
-
-    Accept the default values of the parameters (except for "releaseAsLatest" if backporting).
-
-1. Watch logs of pruner-release.
-
-1. Once the pipeline is complete, check its results:
-
-    ```bash
-    tkn --context dogfooding pr describe <pipeline-run-name>
-
-    (...)
     📝 Results
 
     NAME                    VALUE
     ∙ commit-sha            ff6d7abebde12460aecd061ab0f6fd21053ba8a7
-    ∙ release-file           https://infra.tekton.dev/tekton-releases/pruner/previous/v0.3.4/release.yaml
-    ∙ release-file-no-tag    https://infra.tekton.dev/tekton-releases/pruner/previous/v0.3.4/release.notags.yaml
-
-    (...)
+    ∙ release-file           https://infra.tekton.dev/tekton-releases/pruner/previous/v0.3.6/release.yaml
+    ∙ release-file-no-tag    https://infra.tekton.dev/tekton-releases/pruner/previous/v0.3.6/release.notags.yaml
     ```
 
-    The `commit-sha` should match `$PRUNER_RELEASE_GIT_SHA`.
-    The two URLs can be opened in the browser or via `curl` to download the release manifests.
-
-1. The YAMLs are now released! Anyone installing Tekton Pruner will get the new version. Time to create a new GitHub release announcement:
+1. Create a GitHub release announcement:
 
     1. Find the Rekor UUID for the release
 
     ```bash
+    PRUNER_VERSION=v0.3.6  # Set to the released version
     RELEASE_FILE=https://infra.tekton.dev/tekton-releases/pruner/previous/${PRUNER_VERSION}/release.yaml
     CONTROLLER_IMAGE_SHA=$(curl -L $RELEASE_FILE | sed -n 's/"//g;s/.*ghcr\.io.*controller.*@//p;')
     REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
@@ -118,9 +61,19 @@ the pruner repo, a terminal window and a text editor.
 
     1. Execute the Draft Release Pipeline.
 
-        Create a pod template file:
+        [Setup a context to connect to the dogfooding cluster](#setup-dogfooding-context) if you haven't already.
 
-        ```shell
+        ```bash
+        WORKSPACE_TEMPLATE=$(mktemp /tmp/workspace-template.XXXXXX.yaml)
+        cat <<'EOF' > $WORKSPACE_TEMPLATE
+        spec:
+         accessModes:
+         - ReadWriteOnce
+         resources:
+           requests:
+             storage: 1Gi
+        EOF
+
         POD_TEMPLATE=$(mktemp /tmp/pod-template.XXXXXX.yaml)
         cat <<'EOF' > $POD_TEMPLATE
         securityContext:
@@ -130,43 +83,28 @@ the pruner repo, a terminal window and a text editor.
         EOF
         ```
 
-        ```shell
+        ```bash
+        PRUNER_RELEASE_GIT_SHA=<commit-sha-from-results>
+        PRUNER_OLD_VERSION=v0.3.5  # Previous version
+
         tkn pipeline start \
           --workspace name=shared,volumeClaimTemplateFile="${WORKSPACE_TEMPLATE}" \
           --workspace name=credentials,secret=oci-release-secret \
           --pod-template "${POD_TEMPLATE}" \
-          -p package="${TEKTON_PACKAGE}" \
+          -p package="tektoncd/pruner" \
           -p git-revision="$PRUNER_RELEASE_GIT_SHA" \
           -p release-tag="${PRUNER_VERSION}" \
           -p previous-release-tag="${PRUNER_OLD_VERSION}" \
           -p release-name="Tekton Pruner" \
-          -p repo-name="${PRUNER_REPO_NAME}" \
+          -p repo-name="pruner" \
           -p bucket="tekton-releases" \
           -p rekor-uuid="$REKOR_UUID" \
           release-draft-oci
         ```
 
-    1. Watch logs of resulting pipeline run on pipeline `release-draft-oci`
-
-    1. On successful completion, a URL will be logged. Visit that URL and look through the release notes.
-      1. Manually add upgrade and deprecation notices based on the generated release notes
-      1. Double-check that the list of commits here matches your expectations
-         for the release. You might need to remove incorrect commits or copy/paste commits
-         from the release branch. Refer to previous releases to confirm the expected format.
-
-    1. Un-check the "This is a pre-release" checkbox since you're making a legit for-reals release!
-
-    1. Publish the GitHub release once all notes are correct and in order.
-
-1. Create a branch for the release named `release-<version number>x`, e.g. [`release-v0.3.x`](https://github.com/tektoncd/pruner/tree/release-v0.3.x)
-   and push it to the repo https://github.com/tektoncd/pruner.
-   (This can be done on the Github UI.)
-   Make sure to fetch the commit specified in `PRUNER_RELEASE_GIT_SHA` to create the released branch.
-   > Background: The reason why we need to create a branch for the release named `release-<version number>x` is for future patch releases. Cherrypicked PRs for the patch release will be merged to this branch. For example, [v0.3.0](https://github.com/tektoncd/pruner/releases/tag/v0.3.0) has been already released, but later on we found that an important PR should have been included to that release. Therefore, we need to do a patch release i.e. v0.3.1 by cherrypicking this PR, which will trigger tekton-robot to create a new PR to merge the changes to the [release-v0.3.x branch](https://github.com/tektoncd/pruner/tree/release-v0.3.x).
-
-1. If the release introduces a new minimum version of Kubernetes required,
-   edit `README.md` on `main` branch and add the new requirement with in the
-   "Required Kubernetes Version" section
+    1. On successful completion, visit the logged URL and review the release notes.
+       Manually add upgrade and deprecation notices, verify the commit list, then
+       publish the GitHub release.
 
 1. Edit `releases.md` on the `main` branch, add an entry for the release.
    - In case of a patch release, replace the latest release with the new one,
@@ -177,18 +115,22 @@ the pruner repo, a terminal window and a text editor.
    - Check if any release is EOL, if so move it to the "End of Life Releases"
      section
 
-1. Push & make PR for updated `releases.md` and `README.md`
+1. If the release introduces a new minimum version of Kubernetes required,
+   edit `README.md` on `main` branch and add the new requirement in the
+   "Required Kubernetes Version" section.
 
-1. Test release that you just made against your own cluster (note `--context my-dev-cluster`):
+1. Push & make PR for updated `releases.md` and `README.md`.
+
+1. Test release that you just made against your own cluster:
 
     ```bash
     # Test latest
-    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/pruner/latest/release.yaml
+    kubectl apply --filename https://infra.tekton.dev/tekton-releases/pruner/latest/release.yaml
     ```
 
     ```bash
     # Test backport
-    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/pruner/previous/v0.3.4/release.yaml
+    kubectl apply --filename https://infra.tekton.dev/tekton-releases/pruner/previous/v0.3.6/release.yaml
     ```
 
 1. For major releases, update the [website sync configuration](https://github.com/tektoncd/website/blob/main/sync/config/pruner.yaml)
@@ -197,6 +139,41 @@ the pruner repo, a terminal window and a text editor.
 1. Announce the release in Slack channels #general, #announcements and #pruner.
 
 Congratulations, you're done!
+
+## Manual release (fallback)
+
+If the automated pipeline is unavailable, you can trigger a release manually
+using `tkn`:
+
+```bash
+WORKSPACE_TEMPLATE=$(mktemp /tmp/workspace-template.XXXXXX.yaml)
+cat <<'EOF' > $WORKSPACE_TEMPLATE
+spec:
+ accessModes:
+ - ReadWriteOnce
+ resources:
+   requests:
+     storage: 1Gi
+EOF
+
+tkn --context dogfooding pipeline start pruner-release \
+  --param package=github.com/tektoncd/pruner \
+  --param repoName="pruner" \
+  --param gitRevision="<COMMIT_SHA>" \
+  --param imageRegistry=ghcr.io \
+  --param imageRegistryPath=tektoncd/pruner \
+  --param imageRegistryRegions="" \
+  --param imageRegistryUser=tekton-robot \
+  --param serviceAccountImagesPath=credentials \
+  --param versionTag="<VERSION>" \
+  --param releaseBucket=tekton-releases \
+  --param koExtraArgs="" \
+  --workspace name=release-secret,secret=oci-release-secret \
+  --workspace name=release-images-secret,secret=ghcr-creds \
+  --workspace name=workarea,volumeClaimTemplateFile="${WORKSPACE_TEMPLATE}" \
+  --tasks-timeout 2h \
+  --pipeline-timeout 3h
+```
 
 ## Setup dogfooding context
 
@@ -213,12 +190,7 @@ Congratulations, you're done!
    a short memorable name such as `dogfooding`:
 
    ```bash
-   kubectl config current-context
-   ```
-   get the context name and replace with current_context_name
-
-   ```bash
-   kubectl config rename-context <current_context_name> dogfooding
+   kubectl config rename-context $(kubectl config current-context) dogfooding
    ```
 
 1. **Important: Switch `kubectl` back to your own cluster by default.**


### PR DESCRIPTION

# Changes
Automate releases using [Pipelines-as-Code](https://pipelinesascode.com) instead of manual `tkn pipeline start` commands.
### What's included
- **`.tekton/release.yaml`** — Initial release PipelineRun, triggered automatically when a `release-v*` branch is created. Version derived from branch name via CEL(`release-v0.3.x` → `v0.3.0`).
- **`.tekton/release-patch.yaml`** — Patch release PipelineRun, triggered via PAC incoming webhook. Version and `releaseAsLatest` passed dynamically.
- **`.github/workflows/patch-release.yaml`** — GitHub Actions workflow with two modes:
  - `workflow_dispatch`: manual trigger with branch/version inputs
  - `schedule`: weekly cron (Thursday 10:00 UTC) scanning for unreleased commits on release branches ≥ v0.3
- **Updated `tekton/release-cheat-sheet.md`** — reflects the new automated workflow, with manual `tkn` command preserved as a fallback section.

## Dependencies
- [x] PAC deployed to oci-ci-cd cluster ([tektoncd/plumbing#3256](https://github.com/tektoncd/plumbing/pull/3256))
- [x] PAC Repository CR for tektoncd/pruner (tektoncd/plumbing#3295)
- [ ] Release secrets provisioned in `releases-pruner` namespace ([tektoncd/infra](https://github.com/tektoncd/infra))
- [ ] GitHub App `tekton-as-code` installed on this repo
- [ ] `PAC_INCOMING_SECRET` GitHub Actions secret configured

See [tektoncd/plumbing#58](https://github.com/tektoncd/plumbing/issues/58) for the full automated release plan.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
/kind feature

