### PR TITLE
chore: add zizmor workflow and fix GitHub Actions security findings

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -11,4 +11,5 @@ jobs:
   retest:
     name: Rerun Failed Actions
     uses: tektoncd/plumbing/.github/workflows/_chatops_retest.yml@1cf2292a30268252a734b413b8a44f15c04d1de8 # main
-    secrets: inherit
+    secrets:
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ defaults:
 
 permissions:
   contents: read
-  checks: write  # Used to annotate code in the PR
 
 jobs:
   build:
@@ -22,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -35,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -46,8 +49,13 @@ jobs:
     name: Linting
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write  # Used by golangci-lint-action to annotate code in the PR
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -77,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -91,6 +101,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version-file: "go.mod"
@@ -115,14 +127,21 @@ jobs:
     if: always()
     steps:
     - name: Check CI results
+      env:
+        BUILD_RESULT: ${{ needs.build.result }}
+        UNIT_TESTS_RESULT: ${{ needs.unit-tests.result }}
+        LINTING_RESULT: ${{ needs.linting.result }}
+        CHECK_LICENSES_RESULT: ${{ needs.check-licenses.result }}
+        KO_RESOLVE_RESULT: ${{ needs.ko-resolve.result }}
+        E2E_TESTS_RESULT: ${{ needs.e2e-tests.result }}
       run: |
         results=(
-          "build=${{ needs.build.result }}"
-          "unit-tests=${{ needs.unit-tests.result }}"
-          "linting=${{ needs.linting.result }}"
-          "check-licenses=${{ needs.check-licenses.result }}"
-          "ko-resolve=${{ needs.ko-resolve.result }}"
-          "e2e-tests=${{ needs.e2e-tests.result }}"
+          "build=${BUILD_RESULT}"
+          "unit-tests=${UNIT_TESTS_RESULT}"
+          "linting=${LINTING_RESULT}"
+          "check-licenses=${CHECK_LICENSES_RESULT}"
+          "ko-resolve=${KO_RESOLVE_RESULT}"
+          "e2e-tests=${E2E_TESTS_RESULT}"
         )
         failed=0
         for r in "${results[@]}"; do

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
         with:

--- a/.github/workflows/go-coverage.yaml
+++ b/.github/workflows/go-coverage.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           path: ${{ github.workspace }}/src/github.com/tektoncd/pruner
 
       - name: Set up Go

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,5 +1,8 @@
 name: Pruner kind E2E Tests
 
+permissions:
+  contents: read
+
 'on':
   push:
     branches:

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,5 +1,8 @@
 ---
 name: Label Checker
+
+permissions: {}
+
 'on':
   pull_request:
     types:

--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -1,5 +1,7 @@
 name: Pruner Nightly Build
 
+permissions: {}
+
 "on":
   schedule:
     # Run at 03:00 UTC daily
@@ -40,13 +42,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Generate version info
         id: version
+        env:
+          GIT_SHA: ${{ github.sha }}
         run: |
-          latest_sha=${{ github.sha }}
-          date_tag=$(date +v%Y%m%d-${latest_sha:0:7})
+          latest_sha="${GIT_SHA}"
+          date_tag=$(date "+v%Y%m%d-${latest_sha:0:7}")
           echo "version_tag=${date_tag}" >> "$GITHUB_OUTPUT"
           echo "latest_sha=${latest_sha}" >> "$GITHUB_OUTPUT"
 
@@ -146,21 +151,30 @@ jobs:
           EOF
 
       - name: Start Tekton Build Pipeline
+        env:
+          PARAM_PACKAGE: ${{ env.PACKAGE }}
+          PARAM_REPO_NAME: ${{ env.REPO_NAME }}
+          PARAM_GIT_REVISION: ${{ steps.version.outputs.latest_sha }}
+          PARAM_VERSION_TAG: ${{ steps.version.outputs.version_tag }}
+          PARAM_RELEASE_BUCKET: ${{ env.BUCKET }}
+          PARAM_IMAGE_REGISTRY: ${{ env.REGISTRY }}
+          PARAM_IMAGE_REGISTRY_PATH: ${{ env.IMAGE_REGISTRY_PATH }}
+          PARAM_IMAGE_REGISTRY_USER: ${{ env.IMAGE_REGISTRY_USER }}
         run: |
-          set -euo pipefail  # Exit on any error, undefined variables, or pipe failures
+          set -euo pipefail
 
           echo "Starting Tekton pipeline..."
 
           PIPELINE_RUN=$(tkn pipeline start pruner-release \
             --serviceaccount=release-right-meow \
-            --param package="${{ env.PACKAGE }}" \
-            --param repoName="${{ env.REPO_NAME }}" \
-            --param gitRevision="${{ steps.version.outputs.latest_sha }}" \
-            --param versionTag="${{ steps.version.outputs.version_tag }}" \
-            --param releaseBucket="${{ env.BUCKET }}" \
-            --param imageRegistry=${{ env.REGISTRY }} \
-            --param imageRegistryPath="${{ env.IMAGE_REGISTRY_PATH }}" \
-            --param imageRegistryUser="${{ env.IMAGE_REGISTRY_USER }}" \
+            --param package="${PARAM_PACKAGE}" \
+            --param repoName="${PARAM_REPO_NAME}" \
+            --param gitRevision="${PARAM_GIT_REVISION}" \
+            --param versionTag="${PARAM_VERSION_TAG}" \
+            --param releaseBucket="${PARAM_RELEASE_BUCKET}" \
+            --param imageRegistry="${PARAM_IMAGE_REGISTRY}" \
+            --param imageRegistryPath="${PARAM_IMAGE_REGISTRY_PATH}" \
+            --param imageRegistryUser="${PARAM_IMAGE_REGISTRY_USER}" \
             --param imageRegistryRegions="" \
             --param buildPlatforms="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le" \
             --param publishPlatforms="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64" \
@@ -188,4 +202,4 @@ jobs:
             exit 1
           }
 
-          echo "✅ Pipeline Run completed successfully!"
+          echo "Pipeline Run completed successfully!"

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -1,5 +1,8 @@
 name: Reusable workflow example
 
+permissions:
+  contents: read
+
 "on":
   workflow_call:
     inputs:
@@ -31,6 +34,8 @@ jobs:
     steps:
       - name: Check out our repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
@@ -50,7 +55,7 @@ jobs:
 
       - name: Install Tekton pipelines
         run: |
-          while ! kubectl apply --filename ${{ env.TEKTON_PIPELINES_RELEASE }}
+          while ! kubectl apply --filename "${TEKTON_PIPELINES_RELEASE}"
           do
             echo "waiting for tekton pipelines to get installed"
             sleep 2

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -18,6 +18,9 @@
 # When a command is recognised, the rocket and eyes emojis are added
 
 name: Slash Command Routing
+
+permissions: {}
+
 on:
   issue_comment:
     types:

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -16,6 +16,8 @@ jobs:
           egress-policy: audit
       - name: 'Checkout'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor
+
+"on":
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fix security findings reported by [zizmor](https://docs.zizmor.sh/), a static analysis tool for GitHub Actions, and add zizmor as a CI check.

  **Credential persistence ([artipacked](https://docs.zizmor.sh/audits/#artipacked)):**

  - Add `persist-credentials: false` to all `actions/checkout` steps to prevent credential persistence in the local git config

  **Template injection ([template-injection](https://docs.zizmor.sh/audits/#template-injection)):**

  - Fix template injection by replacing `${{ }}` in `run:` blocks with shell env vars:
    - `${{ github.sha }}` → `${GIT_SHA}` via `env:` block
    - `${{ env.* }}` → `${VAR_NAME}` (env vars are already available as shell vars)
    - `${{ needs.*.result }}` and `${{ steps.*.outputs.* }}` → env vars via `env:` block

  **Excessive permissions ([excessive-permissions](https://docs.zizmor.sh/audits/#excessive-permissions)):**

  - Scope `checks: write` permission to job level instead of workflow level in `ci.yaml`
  - Add top-level `permissions: {}` to `labels.yaml`, `slash.yml`, `nightly-builds.yaml`
  - Add top-level `permissions: contents: read` to `kind-e2e.yaml`, `reusable-e2e.yaml`

  **Secrets inherit ([secrets-inherit](https://docs.zizmor.sh/audits/#secrets-inherit)):**

  - Replace `secrets: inherit` with explicit `secrets: CHATOPS_TOKEN` in `chatops_retest.yaml`

  **Zizmor CI check:**

  - Add `zizmor.yaml` workflow that runs on pushes to main and all PRs
  - Uploads SARIF results to GitHub Advanced Security for stateful triage
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
