### PR TITLE
fix: update release pipeline for oci-ci-cd cluster compatibility

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -96,9 +96,9 @@ spec:
           - name: url
             value: https://github.com/tektoncd/plumbing
           - name: revision
-            value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
+            value: 0dc3174db86dcfa70724eced275ba4c1b2e25e76
           - name: pathInRepo
-            value: tekton/resources/release/base/prerelease_checks.yaml
+            value: tekton/resources/release/base/prerelease_checks_oci.yaml
       params:
         - name: package
           value: $(params.package)
@@ -110,6 +110,8 @@ spec:
         - name: source-to-release
           workspace: workarea
           subPath: git
+        - name: oci-credentials
+          workspace: release-secret
 
     - name: unit-tests
       runAfter: [precheck]
@@ -210,7 +212,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
           - name: name
             value: oracle-cloud-storage-upload
           - name: kind
@@ -243,7 +245,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
           - name: name
             value: oracle-cloud-storage-upload
           - name: kind


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fix release pipeline failures after enabling PAC-triggered releases.
- Use `prerelease_checks_oci.yaml` instead of `prerelease_checks.yaml` since pruner uses Oracle Cloud Storage, not GCS
- Update plumbing revision from `aeed19e5` to `0dc3174d` since old revision had bare image names (`alpine/git`) that fail with CRI-O short name enforcement
- Add `oci-credentials` workspace to precheck task, mapped to `release-secret`
- Bump `oracle-cloud-storage-upload` from `0.1` to `0.2`
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
