### PR TITLE
fix: add e2e build tag to skip e2e tests in release pipeline

### DIFF
--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -76,7 +76,7 @@ jobs:
           echo "Running Go e2e tests"
           set +e
           # Run tests with verbose output to show per-test results
-          go test -v -timeout 35m ./test/... | tee test_output.log
+          go test -v -tags=e2e -timeout 35m ./test/... | tee test_output.log
           test_exit_code=$?
           set -e
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package test
 
 import (


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
- Add `//go:build e2e` and `// +build e2e` build tags to `test/e2e_test.go` — `go test ./...` now skips e2e tests unless `-tags=e2e` is passed
- Add `-tags=e2e` to `go test` in `.github/workflows/reusable-e2e.yaml` so CI e2e tests still run
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Fixes: #288 
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
