### PR TITLE
chore: switch base image to ghcr.io/tektoncd/plumbing/static-base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
     - name: Validate ko resolve for multi-arch
       run: |
         cat <<EOF > .ko.yaml
-        defaultBaseImage: cgr.dev/chainguard/static
+        defaultBaseImage: ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a
         EOF
         # Test that ko can resolve the config for multiple architectures
         KO_DOCKER_REPO=example.com ko resolve --platform=linux/amd64,linux/arm64 --push=false -R -f config 1>/dev/null

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: cgr.dev/chainguard/static:latest
+defaultBaseImage: ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a
 
 builds:
   - id: ko

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -119,7 +119,7 @@ spec:
       # Combine Distroless with a Windows base image, used for the entrypoint image.
       # Distroless is pinned to the last version based on Alpine 3.18. Newer versions are based on Alpine 3.19_alpha20230901.
       COMBINED_BASE_IMAGE=$(go run ./vendor/github.com/tektoncd/plumbing/cmd/combine/main.go \
-        cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7 \
+        ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a \
         mcr.microsoft.com/windows/nanoserver:ltsc2019 \
         mcr.microsoft.com/windows/nanoserver:ltsc2022 \
         ${COMBINED_BASE_IMAGE_BASE}/combined-base-image:latest)

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -96,9 +96,9 @@ spec:
           - name: url
             value: https://github.com/tektoncd/plumbing
           - name: revision
-            value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
+            value: 0dc3174db86dcfa70724eced275ba4c1b2e25e76
           - name: pathInRepo
-            value: tekton/resources/release/base/prerelease_checks.yaml
+            value: tekton/resources/release/base/prerelease_checks_oci.yaml
       params:
         - name: package
           value: $(params.package)
@@ -110,6 +110,8 @@ spec:
         - name: source-to-release
           workspace: workarea
           subPath: git
+        - name: oci-credentials
+          workspace: release-secret
 
     - name: unit-tests
       runAfter: [precheck]
@@ -210,7 +212,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
           - name: name
             value: oracle-cloud-storage-upload
           - name: kind
@@ -243,7 +245,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
           - name: name
             value: oracle-cloud-storage-upload
           - name: kind


### PR DESCRIPTION
# Changes

Switch `defaultBaseImage` to the Tekton-maintained static base image
(`ghcr.io/tektoncd/plumbing/static-base`), built and published from
[tektoncd/plumbing](https://github.com/tektoncd/plumbing/tree/main/tekton/images/static-base).

This image:
- Supports all four target architectures (amd64, arm64, s390x, ppc64le)
- Is rebuilt daily from Alpine packages via apko
- Includes CA certs, timezone data, and nonroot user (UID 65532)
- Is ~300KB per arch

Related: tektoncd/pipeline#9557, tektoncd/plumbing#3434

Replaces `cgr.dev/chainguard/static` in `.ko.yaml`, `tekton/publish.yaml`, and `.github/workflows/ci.yaml`.

# Submitter Checklist

- [x] Has Docs if any changes are user facing
- [x] Has Tests included if any functionality added or changed
- [x] pre-commit Passed
- [x] Follows the commit message standard
- [x] Meets the Tekton contributor standards
- [x] Has a kind label.

/kind cleanup

# Release Notes

```release-note
NONE
```