### PR TITLE
fix(webhook): allow operator-managed global ConfigMap deletion

### DIFF
--- a/pkg/webhook/configmapvalidation.go
+++ b/pkg/webhook/configmapvalidation.go
@@ -255,8 +255,19 @@ func (v *ValidateConfigMap) Admit(ctx context.Context, request *admissionv1.Admi
 
 	// Handle DELETE operations
 	if request.Operation == admissionv1.Delete {
-		// Prevent deletion of global config if namespace configs still exist
+		// Allow deletion of operator-managed global ConfigMaps (owned by a
+		// TektonInstallerSet) — the operator recreates them during config
+		// updates and version upgrades. Otherwise, block deletion if
+		// namespace configs still depend on the global config.
 		if isGlobalConfig {
+			for _, ref := range cm.OwnerReferences {
+				if ref.Kind == "TektonInstallerSet" {
+					logger.Infow("Allowing deletion of operator-managed global config",
+						"name", cm.Name, "owner", ref.Name)
+					return &admissionv1.AdmissionResponse{Allowed: true}
+				}
+			}
+
 			nsList, err := v.Client.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{
 				FieldSelector: "metadata.name=tekton-pruner-namespace-spec",
 			})


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
  - Allow the operator to delete and recreate the global ConfigMap when
    namespace-level ConfigMaps exist, by checking for a TektonInstallerSet
    owner reference before blocking deletion

  ## Problem

  The operator updates the `tekton-pruner-default-spec` ConfigMap by deleting
  the old Config InstallerSet and creating a new one. The InstallerSet finalizer
  deletes the owned ConfigMap as part of cleanup. The pruner webhook intercepts
  this deletion and rejects it if any `tekton-pruner-namespace-spec` ConfigMaps
  exist in the cluster:

`"msg":"failed to delete resources: admission webhook \"validation.webhook.pruner.tekton.dev.global\" denied the request: Cannot delete
  global config: 1 namespace config(s) still exist that depend on it in namespaces: [releasetest-rt7w8]. Delete namespace configs first."`

  The InstallerSet is stuck in deletion, the operator retries every 10 seconds,
  and the old ConfigMap persists forever. This happens during:

  - Config changes (e.g. switching `enforcedConfigLevel` from `global` to
    `namespace`)
  - Version upgrades (e.g. 1.22.4 to 1.23.0)
  - Any spec change that alters the InstallerSet hash

  ## Root Cause

  The webhook treats all deletions of the global ConfigMap the same — whether
  it's a user accidentally deleting it or the operator replacing it as part of
  its lifecycle. The operator's delete-and-recreate pattern for InstallerSet
  updates is incompatible with the webhook's blanket deletion protection.

  ## Fix

  **`pkg/webhook/configmapvalidation.go`**: Before checking for namespace
  ConfigMap dependents, check if the global ConfigMap has a `TektonInstallerSet`
  owner reference. If it does, the deletion is part of the operator's lifecycle
  and the ConfigMap will be recreated — allow it. If it doesn't (manually
  created ConfigMap), enforce the existing protection.

  ```go
  for _, ref := range cm.OwnerReferences {
      if ref.Kind == "TektonInstallerSet" {
          logger.Infow("Allowing deletion of operator-managed global config",
              "name", cm.Name, "owner", ref.Name)
          return &admissionv1.AdmissionResponse{Allowed: true}
      }
  }
```
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
