### PR TITLE
fix(controller): serialize garbage collection triggered by ConfigMap updates

### DIFF
--- a/pkg/reconciler/tektonpruner/controller.go
+++ b/pkg/reconciler/tektonpruner/controller.go
@@ -62,10 +62,14 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	return impl
 }
 
+// gcMutex serializes garbage collection. The ConfigMap watcher starts one
+// goroutine per update, so the mutex must be shared by all of them: declaring it
+// inside safeRunGarbageCollector gave every goroutine a mutex of its own, which
+// serialized nothing and let cluster-wide sweeps run concurrently.
+var gcMutex sync.Mutex
+
 // safeRunGarbageCollector is a thread-safe wrapper around the garbage collection process.
 func safeRunGarbageCollector(ctx context.Context, logger *zap.SugaredLogger) {
-	var gcMutex sync.Mutex
-
 	logger.Debug("Waiting to acquire cleanup thread lock")
 	gcMutex.Lock()
 	defer gcMutex.Unlock()

--- a/pkg/reconciler/tektonpruner/controller_test.go
+++ b/pkg/reconciler/tektonpruner/controller_test.go
@@ -2,7 +2,6 @@ package tektonpruner
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -11,12 +10,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing" // Required for setting system namespace in tests
 
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinefake "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	"github.com/tektoncd/pruner/pkg/config"
 )
 
@@ -136,66 +140,91 @@ failedHistoryLimit: 2`,
 	}
 }
 
+// TestSafeRunGarbageCollector verifies that concurrent triggers never produce
+// overlapping sweeps: the ConfigMap watcher starts one goroutine per update, so a
+// burst of updates must not fan out into concurrent cluster-wide sweeps.
+//
+// Overlap is observed across the two fake clients on purpose. A fake clientset
+// serializes its whole reaction chain under one lock, so a counter kept inside a
+// single client can never see more than one caller at a time. Instead a sweep is
+// counted as in flight when it lists the namespaces (kube client) and counted out
+// when it lists the TaskRuns of the last namespace (pipeline client), and the delay
+// sits in the pipeline client. Unserialized sweeps therefore pile up in the counter,
+// while serialized ones cannot.
 func TestSafeRunGarbageCollector(t *testing.T) {
-	// Create a context with timeout and logging
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	logger := logtesting.TestLogger(t)
 	ctx = logging.WithLogger(ctx, logger)
 
-	// Setup fake client
+	// The sweep loads the ConfigMap from the system namespace; a ConfigMap anywhere
+	// else would make every sweep bail out before doing any work.
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.PrunerConfigMapName,
-			Namespace: "tekton-pipelines",
+			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
 			"global-config": `enforcedConfigLevel: global
 ttlSecondsAfterFinished: 60`,
 		},
 	}
-	client := fake.NewSimpleClientset(cm)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}
 
-	// Inject client into context
-	ctx = context.WithValue(ctx, kubeclient.Key{}, client)
+	kubeClient := fake.NewSimpleClientset(cm, ns)
+	pipelineClient := pipelinefake.NewSimpleClientset()
 
-	// Create a WaitGroup to track goroutines
-	var wg sync.WaitGroup
-	doneChan := make(chan struct{})
-	errChan := make(chan error, 5)
+	var (
+		mu       sync.Mutex
+		inFlight int
+		maxSeen  int
+		sweeps   int
+	)
 
-	// Test concurrent execution safety with error handling
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					errChan <- fmt.Errorf("goroutine %d panicked: %v", id, r)
-				}
-			}()
-			safeRunGarbageCollector(ctx, logger)
-		}(i)
-	}
-
-	// Wait for goroutines in a separate goroutine
-	go func() {
-		wg.Wait()
-		close(doneChan)
-	}()
-
-	// Wait with timeout and error collection
-	select {
-	case <-doneChan:
-		// Check for any errors
-		close(errChan)
-		for err := range errChan {
-			t.Error(err)
+	kubeClient.PrependReactor("list", "namespaces", func(k8stesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		inFlight++
+		sweeps++
+		if inFlight > maxSeen {
+			maxSeen = inFlight
 		}
-	case <-ctx.Done():
-		t.Log("Context cancelled as expected")
-	case <-time.After(3 * time.Second):
-		t.Fatal("Test timed out waiting for garbage collectors to complete")
+		return false, nil, nil // fall through to the tracker
+	})
+
+	pipelineClient.PrependReactor("list", "taskruns", func(k8stesting.Action) (bool, runtime.Object, error) {
+		// Linger here, outside the kube client's lock, so any sweep that was not
+		// serialized shows up in the counter above while this one is still running.
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+		inFlight--
+		return true, &pipelinev1.TaskRunList{}, nil
+	})
+
+	ctx = context.WithValue(ctx, kubeclient.Key{}, kubeClient)
+	ctx = context.WithValue(ctx, pipelineclient.Key{}, pipelineClient)
+
+	const triggers = 5
+
+	var wg sync.WaitGroup
+	for i := 0; i < triggers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			safeRunGarbageCollector(ctx, logger)
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if maxSeen != 1 {
+		t.Errorf("concurrent garbage collection sweeps = %d, want 1", maxSeen)
+	}
+	if sweeps != triggers {
+		t.Errorf("garbage collection sweeps = %d, want %d (one per trigger)", sweeps, triggers)
 	}
 }
 


### PR DESCRIPTION
Fixes #352

# Changes

`safeRunGarbageCollector` is documented as "a thread-safe wrapper around the garbage collection process", but it declared its `sync.Mutex` as a **function-local** variable, so every caller locked a mutex of its own and nothing was serialized. The ConfigMap watcher starts one goroutine per update, so a burst of updates to the pruner ConfigMap fanned out into concurrent cluster-wide sweeps, each listing and pruning PipelineRuns/TaskRuns in every namespace, and each reloading the global config into the shared store while the others were mid-sweep.

This hoists the mutex to package scope so it is shared by all sweeps — what the function already claimed to do. Affects `v0.2.0` through `v0.4.1` and `main`.

`TestSafeRunGarbageCollector` could not catch the bug: it asserted only that concurrent calls do not panic, and it created the ConfigMap in a hardcoded `tekton-pipelines` namespace while `knative.dev/pkg/system/testing` sets the system namespace to `knative-testing` — so every sweep bailed out at the initial ConfigMap lookup without doing any work. It now places the ConfigMap in the system namespace and asserts that sweeps never overlap.

The overlap is observed across the two fake clients on purpose: a fake clientset serializes its whole reaction chain under one lock, so a counter kept inside a single client can never see more than one caller at a time and would pass against the broken code. The test instead counts a sweep in when it lists the namespaces (kube client) and out when it lists the TaskRuns of the last namespace (pipeline client), with the delay in the pipeline client. Against the previous code it reports `concurrent garbage collection sweeps = 5, want 1`; with the mutex shared it reports 1.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed <!-- the repo has no .pre-commit-config.yaml; ran gofmt, go vet and golangci-lint instead, all clean -->

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixed garbage collection not being serialized: a burst of pruner ConfigMap updates could start several cluster-wide pruning sweeps at the same time, duplicating listing and pruning work against the API server.
```

/kind bug

---

> This PR was developed with assistance from Claude (Opus 4.8). All changes were reviewed, understood, tested, and are owned by me. Per the [AI contribution policy](https://github.com/tektoncd/community/blob/main/ai-contribution-policy.md), the commit also carries an `Assisted-by` trailer.
