### PR TITLE
Ignore otel major/minor updates in dependabot

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -20,6 +20,10 @@ ecosystems:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+      - dependency-name: "go.opentelemetry.io/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     cooldown:
       default-days: 7
       semver-major-days: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      - dependency-name: go.opentelemetry.io/*
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     cooldown:
       default-days: 7
       semver-major-days: 30
@@ -74,6 +78,10 @@ updates:
       - kind/misc
     ignore:
       - dependency-name: k8s.io/*
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: go.opentelemetry.io/*
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
@@ -146,6 +154,10 @@ updates:
       - kind/misc
     ignore:
       - dependency-name: k8s.io/*
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: go.opentelemetry.io/*
         update-types:
           - version-update:semver-major
           - version-update:semver-minor


### PR DESCRIPTION
Otel deps must move with knative/pkg; independent bumps are unmergeable.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
