### PR TITLE
  fix(release): resolve in-toto attestation UUID in wait-for-chains

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -386,22 +386,51 @@ spec:
                   echo "Chains signing status: ${SIGNED}"
                   printf '%s' "${SIGNED}" > "$(results.signed.path)"
 
-                  TRANSPARENCY=$(kubectl get taskrun "${TASKRUN_NAME}" -n "${NAMESPACE}" \
-                    -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/transparency}' 2>/dev/null || echo "")
+                  # The release notes verification commands need the in-toto
+                  # *attestation* entry (kind "intoto"), not the per-image
+                  # signature entry (kind "hashedrekord"). The transparency
+                  # annotation points at the signature, so we look up the
+                  # attestation explicitly via the Rekor search index.
+                  REKOR_HOST="https://rekor.sigstore.dev"
+                  REKOR_UUID=""
 
-                  if [ -n "${TRANSPARENCY}" ]; then
-                    echo "Transparency URL: ${TRANSPARENCY}"
-                    REKOR_UUID=$(curl -s "${TRANSPARENCY}" | jq -r 'keys[0]')
-                    if [ -z "${REKOR_UUID}" ] || [ "${REKOR_UUID}" = "null" ]; then
-                      echo "WARNING: Could not extract UUID from transparency URL, falling back to URL"
-                      REKOR_UUID="${TRANSPARENCY}"
-                    fi
-                    echo "Rekor UUID: ${REKOR_UUID}"
-                    printf '%s' "${REKOR_UUID}" > "$(results.rekor-uuid.path)"
-                  else
-                    echo "WARNING: No transparency URL found"
-                    printf 'unknown' > "$(results.rekor-uuid.path)"
+                  IMAGES=$(kubectl get taskrun -n "${NAMESPACE}" \
+                    -l tekton.dev/pipelineRun="${PIPELINERUN}",tekton.dev/pipelineTask=publish-images \
+                    -o jsonpath='{.items[0].status.results[?(@.name=="IMAGES")].value}' 2>/dev/null || echo "")
+                  IMAGE_DIGEST=$(echo "${IMAGES}" | grep -oE 'sha256:[0-9a-f]{64}' | head -1)
+
+                  if [ -n "${IMAGE_DIGEST}" ]; then
+                    echo "Searching Rekor for the in-toto attestation of ${IMAGE_DIGEST}..."
+                    CANDIDATES=$(curl -s -H 'Content-Type: application/json' \
+                      -d "{\"hash\":\"${IMAGE_DIGEST}\"}" \
+                      "${REKOR_HOST}/api/v1/index/retrieve" | jq -r '.[]?' || echo "")
+                    for uuid in ${CANDIDATES}; do
+                      KIND=$(curl -s "${REKOR_HOST}/api/v1/log/entries/${uuid}" \
+                        | jq -r '.[].body' | base64 -d 2>/dev/null | jq -r '.kind' 2>/dev/null || echo "")
+                      if [ "${KIND}" = "intoto" ]; then
+                        REKOR_UUID="${uuid}"
+                        break
+                      fi
+                    done
                   fi
+
+                  if [ -z "${REKOR_UUID}" ]; then
+                    echo "WARNING: Could not find an in-toto attestation entry; falling back to the transparency annotation"
+                    TRANSPARENCY=$(kubectl get taskrun "${TASKRUN_NAME}" -n "${NAMESPACE}" \
+                      -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/transparency}' 2>/dev/null || echo "")
+                    if [ -n "${TRANSPARENCY}" ]; then
+                      REKOR_UUID=$(curl -s "${TRANSPARENCY}" | jq -r 'keys[0]')
+                      if [ -z "${REKOR_UUID}" ] || [ "${REKOR_UUID}" = "null" ]; then
+                        REKOR_UUID=$(echo "${TRANSPARENCY}" | grep -oE 'logIndex=[0-9]+' | cut -d= -f2)
+                      fi
+                    fi
+                  fi
+
+                  if [ -z "${REKOR_UUID}" ]; then
+                    REKOR_UUID="unknown"
+                  fi
+                  echo "Rekor UUID: ${REKOR_UUID}"
+                  printf '%s' "${REKOR_UUID}" > "$(results.rekor-uuid.path)"
                   exit 0
                 fi
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
  ## Summary

  - Fix `wait-for-chains` inline task to resolve the correct Rekor
    UUID (in-toto attestation) instead of the per-image signature
    (hashedrekord) entry
  - Port of tektoncd/pipeline#10363 to this repo

  ## Problem

  The `chains.tekton.dev/transparency` annotation on the publish-images
  TaskRun points at a `hashedrekord` Rekor entry. This entry contains a
  bare signature with no `.Attestation` payload, so the release notes
  verification commands (`rekor-cli get --uuid ... | jq -r .Attestation`)
  return empty. Verified broken on: chains v0.28.1, chains v0.29.0,
  pruner v0.4.0, pruner v0.4.1.

  ## Fix

  Instead of trusting the transparency annotation, the task now:
  1. Reads the `IMAGES` result from the publish-images TaskRun
  2. Searches the Rekor index for all entries matching the first
     image digest
  3. Selects the entry with body kind `intoto`
  4. Falls back to the annotation-based approach if not found
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [pre-commit](https://github.com/tektoncd/pruner/blob/main/DEVELOPMENT.md#install-tools) Passed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind bug